### PR TITLE
Fix dangling reference in Range::Grow(Range&, Range const&) overload

### DIFF
--- a/include/pr/common/range.h
+++ b/include/pr/common/range.h
@@ -262,7 +262,9 @@ namespace pr
 	}
 
 	// Expand 'range' if necessary to include 'rhs'. Returns 'rhs'
-	template <Rangeable T, Rangeable U> inline Range<U> const& Grow(Range<T>& range, Range<U> const& rhs)
+	// Returned by value because 'Range<U>::grow(Range<U>)' returns its by-value parameter,
+	// so binding a reference to it here would dangle as soon as this function returns.
+	template <Rangeable T, Rangeable U> inline Range<U> Grow(Range<T>& range, Range<U> const& rhs)
 	{
 		return range.grow(rhs);
 	}
@@ -351,6 +353,16 @@ namespace pr::common
 			PR_EXPECT(5 == r4.m_end);
 			PR_EXPECT(1 == r4.size());
 			PR_EXPECT(IsWithin(r4, 4));
+
+			// 'Grow(Range<T>&, Range<U> const&)' returns a value, not a reference, because
+			// 'Range<U>::grow(Range<U>)' returns its by-value parameter. Read the returned
+			// range through a copy (not a reference) to confirm this overload is safe to use.
+			IRange r5 = IRange::Reset();
+			IRange r6(4, 8);
+			IRange returned = Grow(r5, r6);
+			PR_EXPECT(4 == r5.m_beg);
+			PR_EXPECT(8 == r5.m_end);
+			PR_EXPECT(returned == r6);
 		}
 		PRUnitTestMethod(IterRange)
 		{


### PR DESCRIPTION
## Bug

In `include/pr/common/range.h`, `Range<U>::grow(Range<U> rhs)` returns its by-value parameter (a temporary):

```cpp
template <Rangeable U> Range<U> grow(Range<U> rhs)
{
    ...
    return rhs;
}
```

The free function overload for two ranges bound that temporary to a reference and returned it:

```cpp
template <Rangeable T, Rangeable U> inline Range<U> const& Grow(Range<T>& range, Range<U> const& rhs)
{
    return range.grow(rhs);
}
```

`range.grow(rhs)` produces a temporary `Range<U>`, which is destroyed at the end of the return statement. The returned `Range<U> const&` is therefore dangling the instant `Grow()` returns to its caller — reading it is undefined behaviour.

## Verification

- MSVC (VS 2026, v145 toolset) emits `C4172: returning address of local variable or temporary` pointing directly at this overload's `return` statement.
- A standalone repro (Debug x64, `/W4`) that binds the result to a reference and then executes unrelated stack-using code before reading it reproduces visibly corrupted values (e.g. `ref.m_beg=-1376824601` instead of the expected `4`). After the fix, the same repro reads back correct values with no warning.
- Searched the whole repo for other call sites of the two-`Range` `Grow` overload — none exist outside `range.h`'s own unit tests (which discard the return value), so this is a self-contained, source-compatible fix.

## Fix

Change the overload to return `Range<U>` by value, matching the by-value contract already used by the single-value `Grow(Range<T>&, U)` overload and by `Range<U>::grow`. Added inline `PR_UNITTESTS` coverage that reads the return value through a copy to lock in the by-value contract.

## Testing

Built and ran a targeted Debug x64 unit-test binary (VS 2026 MSBuild, v145 toolset, `cl /std:c++20 /Od /Zi /MDd /DPR_UNITTESTS=1`) covering `pr::common::TestClass_RangeTests`:

```
pr::common::TestClass_RangeTests.FloatingPointRange.....success. (30 tests)
pr::common::TestClass_RangeTests.General................success. (34 tests)
pr::common::TestClass_RangeTests.ImplicitConversion.....success. (1 test)
pr::common::TestClass_RangeTests.IterRange..............success. (29 tests)
 **** UnitTest results: All 4 unit tests passed. ****
```

(The full `unittests.vcxproj` target pulls in unrelated projects, e.g. `compute`/`view3d-12`, whose NuGet packages aren't restored in this worktree — building just the `range.h` test class in isolation was the smallest relevant validation for this change.)

Out of scope: no changes to `contains`/signed-unsigned handling or `Reset()`.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: beda8025-1dbe-4068-9166-a7a84965b0c7