### PR TITLE
Fix Blake2b SetInput clearing only 16 of 128 input bytes

### DIFF
--- a/include/pr/crypt/blake2b.h
+++ b/include/pr/crypt/blake2b.h
@@ -244,7 +244,7 @@ namespace pr::hash
 		void SetInput(uint8_t input, size_t index)
 		{
 			if (index == 0)
-				memset(&m_input[0], 0, 16);
+				memset(&m_input[0], 0, sizeof(m_input));
 
 			size_t word = index >> 3;
 			size_t byte = index & 7;
@@ -317,6 +317,25 @@ namespace pr::hash
 		auto hash1 = Blake2bHash(str0, sizeof(str0));
 		auto hash2 = Blake2bHash(str1, sizeof(str1));
 		PR_EXPECT(hash1 != hash2);
+
+		// Known-answer test spanning a full 128-byte block plus one extra byte. This exercises the
+		// block-boundary clearing in 'SetInput', which must zero the whole 128-byte input buffer
+		// when starting a new block; clearing only part of it leaves stale bytes from the previous
+		// (full) block corrupting the following (short) block.
+		{
+			uint8_t data[129];
+			for (int i = 0; i != 129; ++i)
+				data[i] = (uint8_t)i;
+
+			auto hash = Blake2bHash(data, sizeof(data));
+			Blake2b<>::hash_t expected = {
+				0xF5, 0x97, 0x11, 0xD4, 0x4A, 0x03, 0x1D, 0x5F, 0x97, 0xA9, 0x41, 0x3C, 0x06, 0x5D, 0x1E, 0x61,
+				0x4C, 0x41, 0x7E, 0xDE, 0x99, 0x85, 0x90, 0x32, 0x5F, 0x49, 0xBA, 0xD2, 0xFD, 0x44, 0x4D, 0x3E,
+				0x44, 0x18, 0xBE, 0x19, 0xAE, 0xC4, 0xE1, 0x14, 0x49, 0xAC, 0x1A, 0x57, 0x20, 0x78, 0x98, 0xBC,
+				0x57, 0xD7, 0x6A, 0x1B, 0xCF, 0x35, 0x66, 0x29, 0x2C, 0x20, 0xC6, 0x83, 0xA5, 0xC4, 0x64, 0x8F,
+			};
+			PR_EXPECT(hash == expected);
+		}
 
 		// This hash doesn't seem to produce the same result as the windows context menu one
 		//auto hash3 = Blake2bHashFile("P:\\pr\\include\\pr\\crypt\\rijndael.h");


### PR DESCRIPTION
## Bug

`Blake2b::SetInput()` clears the 128-byte `m_input` block buffer (`uint64_t m_input[16]`) at the start of each new block with:

```cpp
if (index == 0)
    memset(&m_input[0], 0, 16);
```

This only zeroes the first 16 bytes (2 of the 16 `uint64_t` words), not the full 128-byte buffer. When a full 128-byte block is followed by a shorter block, the shorter block's unset words still contain stale bytes from the previous block, corrupting the hash.

## Reproduction

Compiled the header standalone and hashed a 129-byte sequential input (one full block + 1 byte), comparing against Python's `hashlib.blake2b` (reference BLAKE2b implementation):

- 64-byte input (single block): matches reference exactly.
- 129-byte input (full block + short block): **did not match** reference before the fix, confirming the bug is isolated to the block-boundary clearing.

## Fix

```cpp
memset(&m_input[0], 0, sizeof(m_input));
```

## Test

Added an inline `PR_UNITTESTS` known-answer test (129-byte sequential input, comparing against the reference BLAKE2b hash) to the existing `Blake2bTests`. Verified:
- **Before fix**: test fails (`'hash == expected' failed`).
- **After fix**: test passes.

Built and ran a Debug x64 harness (VS 2026 / v145 toolset, `/std:c++20`) exercising the real `pr::unittests` framework and the `PRUnitTest` block embedded in `blake2b.h`:

```
 **** Begin Unit Tests ****
pr::hash::TestClass_Blake2bTests.Blake2bTests....success. (2 tests in 0.031 ms)
 **** UnitTest results: All 1 unit tests passed. (taking 0.208 ms) ****
```

No other changes (key/digest-size handling untouched).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: fead946b-925e-4eb8-9892-a2c9386ade57