### PR TITLE
Fix stale-task replay in ThreadPool worker loop

### DIFF
--- a/include/pr/threads/thread_pool.h
+++ b/include/pr/threads/thread_pool.h
@@ -82,8 +82,16 @@ namespace pr::threads
 		{
 			SetCurrentThreadName("ThreadPool Worker");
 
-			for (std::function<void()> task;;)
+			for (;;)
 			{
+				// Declared fresh each iteration (rather than once outside the loop) so that a
+				// failed 'try_pop' below reliably leaves 'task' empty. 'concurrent_queue::try_pop'
+				// only writes its output on success, so a shared, reused 'task' would otherwise
+				// retain the previous iteration's callable, letting the '!task' guards below
+				// mistake it for a genuinely pending task and re-run it instead of popping the
+				// next queued task.
+				std::function<void()> task;
+
 				// If there are no tasks, wait for a signal
 				if (!m_tasks.try_pop(task))
 				{
@@ -140,6 +148,47 @@ namespace pr::threads
 	//	auto result = pool.QueueTaskR([] { std::this_thread::sleep_for(std::chrono::milliseconds(100)); return 42; });
 	//	PR_EXPECT(result.get() == 42);
 #endif
+	}
+
+	// Regression test for a bug where a completed task could be re-run: the worker loop kept a
+	// single 'task' variable across iterations, and 'concurrent_queue::try_pop' leaves its output
+	// unchanged when the queue is empty. That meant a failed pop after a task finished left the
+	// just-run task sitting in the loop variable, which then bypassed the "do we have work" guard
+	// and got executed again instead of the next queued task.
+	PRUnitTest(ThreadPoolStaleTaskReplayTest)
+	{
+		// A single worker thread makes the interleaving deterministic: there's exactly one thread
+		// that can dequeue/execute tasks, so the only variable is timing between task 'A' finishing
+		// and task 'B' being queued from this thread.
+		ThreadPool pool(1);
+		std::atomic_int count_a = 0;
+		std::atomic_int count_b = 0;
+		std::atomic_bool a_ran = false;
+
+		pool.QueueTask([&]
+		{
+			++count_a;
+			a_ran = true;
+		});
+
+		// Wait for 'A' to have run at least once.
+		while (!a_ran)
+			std::this_thread::yield();
+
+		// Widen the race window: give the worker thread a chance to loop back to the (now empty)
+		// queue and hit the failed 'try_pop' before 'B' is queued. This is not required for
+		// correctness after the fix (the outcome is deterministic regardless of timing), it only
+		// increases the chance of catching a regression that reintroduces the stale-task bug.
+		std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+		pool.QueueTask([&]
+		{
+			++count_b;
+		});
+
+		pool.WaitAll();
+		PR_EXPECT(count_a == 1);
+		PR_EXPECT(count_b == 1);
 	}
 }
 #endif


### PR DESCRIPTION
## Bug

`include/pr/threads/thread_pool.h`'s `ThreadMain` worker loop declared its `std::function<void()> task` variable once, outside/across loop iterations:

```cpp
for (std::function<void()> task;;)
{
    if (!m_tasks.try_pop(task))
    { ... }
    task();
    ...
}
```

`concurrency::concurrent_queue::try_pop` only writes to its output parameter when it succeeds — on failure (empty queue) it leaves `task` untouched. Once the queue became empty after a task ran, the next `try_pop` failed but left the just-executed task sitting in `task` (stale, but still truthy). The `if (!task && !m_tasks.try_pop(task))` guard used later to decide whether a real task was popped then treated that stale value as "we have work," so the loop re-executed the *previous* task instead of dequeuing the newly queued one — task replay — and unconditionally decremented `m_tasks_pending`, eventually tripping the `assert(m_tasks_pending >= 0)`.

## Fix

Declare `task` fresh inside each loop iteration, so a failed `try_pop` reliably leaves it default-constructed (empty/falsy), restoring the correctness of the `!task` guards. This is a minimal, targeted fix — the queue's `try_pop` semantics (external, MS PPL header) are unchanged, and no other synchronization behavior in the loop was touched.

Note: a pre-existing, separately-disabled test (`ThreadPoolTests`, guarded by `#if 0`) mentions a race that can hang — that looks like a distinct lost-wakeup issue and is left untouched, out of scope for this PR.

## Repro & verification

- Added `PRUnitTest(ThreadPoolStaleTaskReplayTest)` in `thread_pool.h`: a single-worker-thread pool runs task A, waits for it to complete, then queues task B; asserts each task ran exactly once.
- Before the fix: reproduced the assertion failure (`m_tasks_pending >= 0`) in **10/10** standalone runs against the unfixed header.
- After the fix: **30/30** standalone runs pass, and the full `unittests.vcxproj` (Debug x64, VS 2026 / v145 toolset) builds clean and passes **all 965 unit tests**, including the new regression test, across 5 repeated runs.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 4a869b02-360e-4d7a-a8e9-1acc4404b1b3