### PR TITLE
Fix pr::container::vector operator== to advance iterators

### DIFF
--- a/include/pr/container/vector.h
+++ b/include/pr/container/vector.h
@@ -1283,7 +1283,7 @@ namespace pr
 			if (lhs.size() != rhs.size()) return false;
 			auto lptr = std::begin(lhs);
 			auto rptr = std::begin(rhs);
-			for (auto n = lhs.size(); n-- != 0;)
+			for (auto n = lhs.size(); n-- != 0; ++lptr, ++rptr)
 				if (!(*lptr == *rptr)) return false;
 
 			return true;
@@ -1903,6 +1903,25 @@ namespace pr::container
 						PR_EXPECT(vec0[i].val == arr0[i].val);
 				}
 			}*/
+			{// operator == / != must compare every element, not just the first
+				Check chk;
+				{
+					Array0 arr0 = { 1, 2 };
+					Array0 arr1 = { 1, 2 };
+					PR_EXPECT(arr0 == arr1);
+					PR_EXPECT(!(arr0 != arr1));
+				}{
+					Array0 arr0 = { 1, 2 };
+					Array0 arr1 = { 3, 2 };
+					PR_EXPECT(!(arr0 == arr1));
+					PR_EXPECT(arr0 != arr1);
+				}{
+					Array0 arr0 = { 1, 2 };
+					Array0 arr1 = { 1, 3 };
+					PR_EXPECT(!(arr0 == arr1));
+					PR_EXPECT(arr0 != arr1);
+				}
+			}
 		}
 		PRUnitTestMethod(Mem)
 		{


### PR DESCRIPTION
## Bug
`pr::container::vector`'s `operator==` (include/pr/container/vector.h) loops over every element but never advances `lptr`/`rptr`, so it repeatedly compares element 0 against element 0. Two vectors that share their first element but differ later — e.g. `{1,2}` vs `{1,3}` — incorrectly compare as equal.

## Fix
Advance both iterators each loop iteration (`++lptr, ++rptr`), matching the loop's element-count decrement.

## Tests
Added focused `PR_UNITTESTS` coverage in the existing `Operators` test method:
- Equal vectors compare equal (`==` true, `!=` false)
- Vectors differing in the first element compare unequal
- Vectors differing only in a later element compare unequal (the regression case)

## Verification
- Built `projects\tests\unittests\unittests.vcxproj` (Debug x64, VS 2026 MSBuild v145).
- Confirmed the new differing-later-element test **fails** without the fix (reproducing the bug), and **passes** with the fix.
- Full unit test suite: **all 964 unit tests pass** with the fix applied.

Scope limited to this bug only — no changes to `resize` or other vector behavior.