### PR TITLE
Fix unsafe implicit downcast in RefPtr conversion operator

### DIFF
--- a/include/pr/common/refptr.h
+++ b/include/pr/common/refptr.h
@@ -1,4 +1,4 @@
-﻿//**********************************************************************************
+//**********************************************************************************
 // Pointer to a reference counted object
 //  Copyright (c) Rylogic Ltd 2011
 //**********************************************************************************
@@ -172,12 +172,17 @@ namespace pr
 			return m_ptr != nullptr;
 		}
 
-		// Implicit conversion to base class
-		template <typename U, class = typename std::enable_if<std::is_convertible<U*,T*>::value>::type>
-		operator RefPtr<U>() const
-		{
-			return RefPtr<U>(static_cast<U*>(m_ptr), true);
-		}
+		// Note: there is deliberately no 'operator RefPtr<U>()' conversion operator here.
+		// The templated copy/move constructors above already provide the only implicit
+		// conversion that is safe: from RefPtr<T> to RefPtr<U> whenever 'T*' converts to
+		// 'U*' (i.e. 'U' is a base of 'T', or 'T' itself), since that direction can't slice
+		// or misrepresent the pointee's actual type. A member conversion operator enabled
+		// for that same direction would be redundant with those constructors and would make
+		// the conversion ambiguous, because both become equally-good user-defined conversions
+		// for the same source/target pair. Enabling it for the opposite direction instead
+		// would let a RefPtr<Base> silently, implicitly "convert" to a RefPtr<Derived> - an
+		// unchecked downcast that the compiler can't verify. Use an explicit static_cast or
+		// dynamic_cast on the raw pointer if a downcast is genuinely needed.
 
 		// Pointer de-reference
 		T* operator -> () const
@@ -327,3 +332,43 @@ namespace pr
 	}
 }
 
+#if PR_UNITTESTS
+#include "pr/common/unittests.h"
+namespace pr::common
+{
+	PRUnitTestClass(TestRefPtr)
+	{
+		struct Thing : RefCount<Thing>
+		{
+			virtual ~Thing() = default;
+			virtual int Kind() const { return 0; }
+		};
+		struct Derived : Thing
+		{
+			int Kind() const override { return 1; }
+		};
+		struct Unrelated : RefCount<Unrelated>
+		{
+		};
+
+		PRUnitTestMethod(ConversionDirection)
+		{
+			// The safe upcast (derived -> base) must be implicit.
+			static_assert(std::is_convertible_v<RefPtr<Derived>, RefPtr<Thing>>, "RefPtr<Derived> should implicitly convert to RefPtr<Thing> (its base)");
+
+			// The unsafe downcast (base -> derived) must not be implicit; it can't be checked at compile time.
+			static_assert(!std::is_convertible_v<RefPtr<Thing>, RefPtr<Derived>>, "RefPtr<Thing> must not implicitly convert to RefPtr<Derived>");
+
+			// Unrelated types must not be convertible in either direction.
+			static_assert(!std::is_convertible_v<RefPtr<Unrelated>, RefPtr<Thing>>, "RefPtr<Unrelated> must not implicitly convert to RefPtr<Thing>");
+			static_assert(!std::is_convertible_v<RefPtr<Thing>, RefPtr<Unrelated>>, "RefPtr<Thing> must not implicitly convert to RefPtr<Unrelated>");
+
+			// Exercise the allowed upcast at runtime, not just via the type trait.
+			RefPtr<Derived> d(new Derived(), true);
+			RefPtr<Thing> b = d;
+			PR_EXPECT(b->Kind() == 1);
+			PR_EXPECT(b.RefCount() == 2);
+		}
+	};
+}
+#endif

--- a/projects/tests/unittests/src/unittests.h
+++ b/projects/tests/unittests/src/unittests.h
@@ -60,6 +60,7 @@
 #include "pr/common/packing.h"
 #include "pr/common/pe_file.h"
 #include "pr/common/range.h"
+#include "pr/common/refptr.h"
 #include "pr/common/registrykey.h"
 #include "pr/common/repeater.h"
 #include "pr/common/scope.h"


### PR DESCRIPTION
## Defect

`pr::RefPtr<T>::operator RefPtr<U>()` (`include/pr/common/refptr.h`) was gated on:

```cpp
template <typename U, class = typename std::enable_if<std::is_convertible<U*,T*>::value>::type>
operator RefPtr<U>() const
```

This condition is backwards: the operator converts *from* `RefPtr<T>` *to* `RefPtr<U>`, but requiring `is_convertible<U*,T*>` means `U` must be a *derived* type of `T`. In practice this let a `RefPtr<Base>` silently, implicitly convert to a `RefPtr<Derived>` — an unchecked, unverifiable downcast — while doing nothing for the actually-safe upcast direction (`RefPtr<Derived>` → `RefPtr<Base>`).

## Investigation

I verified the bug and the fix with compile-time probes (`std::is_convertible` static_asserts plus real overload-resolution usage):

- **Confirmed defect**: with the original code, `std::is_convertible<RefPtr<Base>, RefPtr<Derived>>` is `true` — an unsafe downcast compiles silently.
- **Naive fix rejected**: simply flipping the condition to `std::is_convertible<T*,U*>` (so the operator applies in the safe upcast direction) creates a genuine ambiguity. `RefPtr<U>` already has templated copy/move constructors that provide this exact same safe conversion. With both the constructor (on the target type) and a same-direction conversion operator (on the source type) viable for the same source/target pair, overload resolution becomes ambiguous, breaking currently-working upcasts (e.g. `RefPtr<Base> b = derived_ptr;` and passing a `RefPtr<Derived>` to a function taking `RefPtr<Base>`).

## Fix

Since the templated converting constructors already provide the correct, safe upcast conversion on their own, the conversion operator is redundant when pointed in the safe direction, and actively unsafe when pointed in the (original) unsafe direction. The smallest correct fix is to **remove the conversion operator entirely**.

## Verification

- Added `PRUnitTestClass(TestRefPtr)` in `refptr.h` with:
  - `static_assert(std::is_convertible_v<RefPtr<Derived>, RefPtr<Base>>)` — safe upcast still implicit.
  - `static_assert(!std::is_convertible_v<RefPtr<Base>, RefPtr<Derived>>)` — unsafe downcast now rejected.
  - Unrelated-type static_asserts (neither direction convertible).
  - A runtime check exercising the upcast through the real constructor/ref-counting path.
- Registered `refptr.h` in `projects/tests/unittests/src/unittests.h` so the new test is included in the unit test binary.
- Built and ran the test with VS 2026 MSBuild (v145 toolset), Debug x64 flags matching the project (`/std:c++latest /MTd /Od /D_DEBUG /DNOMINMAX /DWIN32_LEAN_AND_MEAN`), using the real `pr::unittests` framework:
  ```
  **** Begin Unit Tests ****
  pr::common::TestClass_TestRefPtr.ConversionDirection...success. (2 tests in 0.003 ms)
  **** UnitTest results: All 1 unit tests passed. ****
  ```
  (Building the full `unittests.vcxproj` solution wasn't possible in this environment because the fresh worktree has no NuGet package cache — an unrelated pre-existing setup issue — so I verified via a standalone Debug x64 compile against the real production header and the real test framework instead.)

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: c27c95fe-b642-4966-83ad-50a2305f234d