### PR TITLE
Fix matrix subtraction transpose handling

### DIFF
--- a/include/pr/math/tests/matrix_tests.h
+++ b/include/pr/math/tests/matrix_tests.h
@@ -169,6 +169,23 @@ namespace pr::math::tests
 					PR_EXPECT(m(r, c) == t(c, r));
 		}
 
+		PRUnitTestMethod(SubtractTransposeStates, float, double)
+		{
+			using mat_t = Matrix<T>;
+
+			// Use a non-square matrix so the logical shape and the physical layout are easy to distinguish.
+			auto m = mat_t(2, 3, { T(1), T(2), T(3), T(4), T(5), T(6) });
+			auto mt = mat_t(2, 3, { T(1), T(4), T(2), T(5), T(3), T(6) }, true);
+
+			// Same-flag subtraction should stay on the raw-buffer path for both normal and transposed matrices.
+			PR_EXPECT(FEql(m - m, mat_t::Zero(2, 3)));
+			PR_EXPECT(FEql(mt - mt, mat_t::Zero(2, 3)));
+
+			// Mixed-flag subtraction must fall back to element-by-element access so logically equal matrices cancel out.
+			PR_EXPECT(FEql(m, mt));
+			PR_EXPECT(FEql(m - mt, mat_t::Zero(2, 3)));
+		}
+
 		PRUnitTestMethod(Resizing)
 		{
 			auto M = Matrix<double>::Random(rng, 4, 3, -5.0, 5.0);

--- a/include/pr/math/types/matrix.h
+++ b/include/pr/math/types/matrix.h
@@ -489,12 +489,12 @@ namespace pr::math
 			pr_assert(lhs.vecs() == rhs.vecs());
 			pr_assert(lhs.cmps() == rhs.cmps());
 
-			// If one of the matrices is transposed, we need to subtract element-by-element
-			// If both are transposed (or not), we can vectorise element substracting
+			// If both matrices have the same transposed state, we can subtract the raw buffer directly.
+			// If one matrix is transposed and the other is not, we must subtract element-by-element.
 			// Return a matrix consist with the common transposed state
-			if (lhs.m_transposed != rhs.m_transposed)
+			if (lhs.m_transposed == rhs.m_transposed)
 			{
-				// If both are not transposed, we can vectorise element subtracting
+				// Raw-buffer subtraction is valid because both operands share the same physical layout.
 				Matrix<S> res(lhs.m_vecs, lhs.m_cmps);
 				res.m_transposed = lhs.m_transposed;
 				for (int i = 0, iend = res.size(); i != iend; ++i)


### PR DESCRIPTION
Fix `Matrix::operator-` so the raw-buffer fast path matches `operator+` and only runs when both operands share the same transposed state.

Adds a regression test covering same-flag and mixed-flag subtraction on a non-square matrix.