### PR TITLE
Remove redundant min_max fix include

### DIFF
--- a/include/pr/meta/min_max.h
+++ b/include/pr/meta/min_max.h
@@ -4,7 +4,6 @@
 //******************************************
 
 #pragma once
-#include "pr/common/min_max_fix.h"
 
 namespace pr
 {


### PR DESCRIPTION
Remove the unused `pr/common/min_max_fix.h` dependency from `pr/meta/min_max.h`. The template code in this header only uses language operators and qualified names, and the standalone Windows-macro compile plus the Debug x64 unittests build both passed after restoring the missing local native packages.