### PR TITLE
Fix Plane3::FromBestFit sign

### DIFF
--- a/include/pr/math/primitives/plane.h
+++ b/include/pr/math/primitives/plane.h
@@ -96,7 +96,7 @@ namespace pr::math
 				centre += *j;
 			}
 			p = Normalise(p);
-			p.w = Dot(centre, p) / (end - begin); // Centre / (end - begin) is the true centre
+			p.w = -Dot(centre, p) / (end - begin); // Centre / (end - begin) is the true centre, so use it as a point on the plane (Dot(plane, point) == 0)
 			return Plane3{ p };
 		}
 	};

--- a/include/pr/math/tests/plane_tests.h
+++ b/include/pr/math/tests/plane_tests.h
@@ -41,6 +41,47 @@ namespace pr::math::tests
 			PR_EXPECT(FEql(norm.direction(), V4(0, 0, 1, 0)));
 		}
 
+		// Verify that the best-fit plane passes through the input points, and that reversing
+		// the winding only flips the sign of the signed distance while preserving the magnitude.
+		PRUnitTestMethod(FromBestFit, float, double)
+		{
+			using V4 = Vec4<T>;
+			using P = Plane3<T>;
+
+			V4 const points_ccw[] =
+			{
+				V4(0, 0, 5, 1),
+				V4(1, 0, 5, 1),
+				V4(1, 1, 5, 1),
+				V4(0, 1, 5, 1),
+			};
+			V4 const points_cw[] =
+			{
+				V4(0, 0, 5, 1),
+				V4(0, 1, 5, 1),
+				V4(1, 1, 5, 1),
+				V4(1, 0, 5, 1),
+			};
+			auto const origin = V4(0, 0, 0, 1);
+
+			auto check = [&](auto const& points, T expected_signed_distance)
+			{
+				auto plane = P::FromBestFit(points);
+
+				// Every input point should satisfy the plane equation.
+				for (auto const& point : points)
+					PR_EXPECT(FEql(Distance(plane, point), T(0)));
+
+				// The signed distance changes with winding, but the geometric distance does not.
+				auto signed_distance = Distance(plane, origin);
+				PR_EXPECT(FEql(signed_distance, expected_signed_distance));
+				PR_EXPECT(FEql(Abs(signed_distance), T(5)));
+			};
+
+			check(points_ccw, T(-5));
+			check(points_cw, T(5));
+		}
+
 		PRUnitTestMethod(NormaliseTest, float, double)
 		{
 			using V4 = Vec4<T>;


### PR DESCRIPTION
Fix the best-fit plane offset sign so coplanar points at non-zero distance from the origin lie on the returned plane.

Adds regression coverage for coplanar points at z=5 and for winding-dependent signed distance semantics.