### PR TITLE
Fix pr::meta::square_root truncation on 64-bit size_t

### DIFF
--- a/include/pr/meta/square_root.h
+++ b/include/pr/meta/square_root.h
@@ -1,9 +1,18 @@
 // Algorithm from this page: http://www.embedded.com/98/9802fe2.htm
+// This is the classic digit-by-digit (base-4) integer square root algorithm: each iteration
+// pulls the next 2 bits off the top of N and appends one bit to Root, so it needs Bits/2
+// iterations to consume all of N's bits, where Bits is the width of std::size_t. Each
+// iteration exposes the next 2 bits by right-shifting N by Bits-2, so that shift amount
+// must also scale with Bits rather than being a fixed constant - hardcoding both values to
+// the width of a 32-bit size_t silently truncated the result on platforms (e.g. x64) where
+// std::size_t is wider than 32 bits.
 
+#pragma once
 #ifndef PR_META_SQRT_H
 #define PR_META_SQRT_H
 
-#include "pr/meta/Constants.h"
+#include <cstddef>
+#include "pr/meta/constants.h"
 
 namespace pr
 {
@@ -11,17 +20,17 @@ namespace pr
 	{
 		namespace impl
 		{
-			template <std::size_t Iter, std::size_t N, std::size_t Root = 0, std::size_t Rem = 0>
+			template <std::size_t Iter, std::size_t Shift, std::size_t N, std::size_t Root = 0, std::size_t Rem = 0>
 			struct square_root_iter
 			{
 				static const std::size_t divisor = (Root << 2) + 1;
-				static const std::size_t nextrem = (Rem  << 2) + (N >> 30);
+				static const std::size_t nextrem = (Rem  << 2) + (N >> Shift);
 				static const std::size_t mult	 = !!(divisor <= nextrem);
-				static const std::size_t value	 = square_root_iter<Iter - 1, N << 2, (Root << 1) + mult, nextrem - mult * divisor>::value;
+				static const std::size_t value	 = square_root_iter<Iter - 1, Shift, N << 2, (Root << 1) + mult, nextrem - mult * divisor>::value;
 			};
 
-			template <std::size_t N, std::size_t Root, std::size_t Rem>
-			struct square_root_iter<0, N, Root, Rem>
+			template <std::size_t Shift, std::size_t N, std::size_t Root, std::size_t Rem>
+			struct square_root_iter<0, Shift, N, Root, Rem>
 			{
 				static const std::size_t value = Root;
 			};
@@ -30,10 +39,67 @@ namespace pr
 		template <std::size_t N>
 		struct square_root
 		{
-			static const std::size_t value = impl::square_root_iter<16, N>::value;
+			// std::size_t's bit width determines how many 2-bit digits of N need to be consumed,
+			// and where in N the top 2 bits sit before each iteration's left-shift by 2.
+			static const std::size_t bits  = sizeof(std::size_t) * 8;
+			static const std::size_t value = impl::square_root_iter<bits / 2, bits - 2, N>::value;
 		};
 
 	}
 }
 
 #endif PR_META_SQRT_H
+
+#if PR_UNITTESTS
+#include "pr/common/unittests.h"
+#include "pr/meta/is_prime.h"
+#include "pr/meta/prime_gtreq.h"
+namespace pr::meta
+{
+	PRUnitTest(SquareRootTests)
+	{
+		// 0/1 boundaries, and exact vs non-exact squares
+		static_assert(square_root<0>::value == 0, "");
+		static_assert(square_root<1>::value == 1, "");
+		static_assert(square_root<2>::value == 1, "");
+		static_assert(square_root<3>::value == 1, "");
+		static_assert(square_root<4>::value == 2, "");
+		static_assert(square_root<5>::value == 2, "");
+		static_assert(square_root<8>::value == 2, "");
+		static_assert(square_root<9>::value == 3, "");
+		static_assert(square_root<15>::value == 3, "");
+		static_assert(square_root<16>::value == 4, "");
+		static_assert(square_root<17>::value == 4, "");
+		static_assert(square_root<24>::value == 4, "");
+		static_assert(square_root<25>::value == 5, "");
+		static_assert(square_root<26>::value == 5, "");
+		static_assert(square_root<65535>::value == 255, "");
+		static_assert(square_root<65536>::value == 256, "");
+		static_assert(square_root<65537>::value == 256, "");
+		static_assert(square_root<999999>::value == 999, "");
+		static_assert(square_root<1000000>::value == 1000, "");
+		static_assert(square_root<1000001>::value == 1000, "");
+
+		// Values that straddle the 32-bit boundary, and the largest representable size_t
+		static_assert(square_root<4294967295ULL>::value == 65535, "");                        // 2^32 - 1
+		static_assert(square_root<4294967296ULL>::value == 65536, "");                        // 2^32
+		static_assert(square_root<4294967297ULL>::value == 65536, "");                        // 2^32 + 1
+		static_assert(square_root<18446744065119617025ULL>::value == 4294967295ULL, "");       // (2^32 - 1)^2
+		static_assert(square_root<18446744073709551615ULL>::value == 4294967295ULL, "");       // 2^64 - 1 (SIZE_MAX)
+
+		// is_prime/prime_gtreq use square_root as an upper bound for trial division, so an
+		// underestimated square root would let them stop before ruling out a real factor.
+		static_assert(is_prime<2>::value == true, "");
+		static_assert(is_prime<3>::value == true, "");
+		static_assert(is_prime<4>::value == false, "");
+		static_assert(is_prime<17>::value == true, "");
+		static_assert(is_prime<25>::value == false, ""); // 5*5, exactly at sqrt(25)
+		static_assert(is_prime<49>::value == false, ""); // 7*7
+		static_assert(is_prime<997>::value == true, "");
+		static_assert(is_prime<999983>::value == true, "");
+		static_assert(is_prime<999999>::value == false, "");
+		static_assert(prime_gtreq<10>::value == 11, "");
+		static_assert(prime_gtreq<1000000>::value == 1000003, "");
+	}
+}
+#endif

--- a/projects/tests/unittests/src/unittests.h
+++ b/projects/tests/unittests/src/unittests.h
@@ -144,6 +144,7 @@
 #include "pr/meta/gcf.h"
 #include "pr/meta/min_max.h"
 #include "pr/meta/nameof.h"
+#include "pr/meta/square_root.h"
 #include "pr/network/email.h"
 #include "pr/network/pipe.h"
 #include "pr/network/pipe2.h"


### PR DESCRIPTION
## Bug

`include/pr/meta/square_root.h` implements a digit-by-digit integer square root, but hardcoded **16 iterations** and a shift of **30 bits** — values that only make sense when `std::size_t` is 32 bits wide (16 iterations × 2 bits/iteration = 32 bits consumed). On 64-bit platforms this only extracts the top 32 bits of `N`, silently producing wrong results for most `N ≥ 5` and severe underestimates for `N > 2^32`.

Confirmed with a standalone probe (`sizeof(size_t) == 8` on this platform):

| N | Old `Sqrt<N>::value` | Correct floor(sqrt(N)) |
|---|---|---|
| 8 | 3 | 2 |
| 16 | 5 | 4 |
| 1,000,000 | 1023 | 1000 |
| 4294967296 (2^32) | 65535 | 65536 |
| 18446744065119617025 ((2^32-1)^2) | 65535 | 4294967295 |

Consumers `is_prime.h` / `prime_gtreq.h` use `square_root<N>::value` as the trial-division upper bound, so an **underestimate** (as happens above 2^32) can let primality testing stop before ruling out a real factor.

## Fix

- Generalized the iteration count and shift amount to `sizeof(std::size_t) * 8` (bits) / `bits/2` / `bits-2`, so the algorithm consumes all of `N`'s bits regardless of `size_t` width. The public `square_root<N>::value` API is unchanged.
- Added the header's own `<cstddef>` include (it used `std::size_t` without including it, relying on transitive includes).
- Added `#pragma once` alongside the existing manual `#ifndef` guard, matching sibling headers `is_prime.h`/`prime_gtreq.h`. This was needed because `is_prime.h` includes `square_root.h` back; without `#pragma once`, that nested include re-read the trailing `PR_UNITTESTS` block a second time before `is_prime.h`'s own declarations were in scope, breaking compilation once tests were added.
- Added compile-time `static_assert` tests (0/1 boundaries, exact/non-exact squares, the 32-bit boundary, and `SIZE_MAX`), plus consumer checks via `is_prime`/`prime_gtreq`.

## Testing

- Standalone `cl.exe` probes (with matching project flags) confirmed the bug and then the fix, across boundary values and consumer primality checks.
- Regenerated `projects/tests/unittests/src/unittests.h` via `HarvestFiles.csx` so the new `PR_UNITTESTS` block gets picked up.
- Built `unittests.vcxproj` Debug x64 (VS 2026 / v145) after building its native dependencies (`lua`, `physics`, `view3d-12`, `compute`): **all 969 unit tests passed**, including the new `SquareRootTests`.

No unrelated meta traits were modified.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 3b251193-ac9d-4be1-a890-ea2a5ef86ffc