### PR TITLE
Fix reverse bits boundaries

### DIFF
--- a/include/pr/algorithm/fast_fourier_transform.h
+++ b/include/pr/algorithm/fast_fourier_transform.h
@@ -531,6 +531,23 @@ namespace pr::algorithm::fft::tests
 			err = Log10RMSError(expectr.data(), expecti.data(), actualr.data(), actuali.data(), n);
 		}
 
+		// Length one reaches the bit-reversal path with zero levels, so keep that boundary covered directly.
+		PRUnitTestMethod(LengthOneRegression)
+		{
+			std::vector<double> inputr{ 1.25 };
+			std::vector<double> inputi{ -0.5 };
+			std::vector<double> actualr(1);
+			std::vector<double> actuali(1);
+
+			DiscreteFourierTransform(inputr.data(), inputi.data(), actualr.data(), actuali.data(), 1);
+			PR_EXPECT(actualr[0] == inputr[0]);
+			PR_EXPECT(actuali[0] == inputi[0]);
+
+			InverseDiscreteFourierTransform(actualr.data(), actuali.data(), actualr.data(), actuali.data(), 1);
+			PR_EXPECT(actualr[0] == inputr[0]);
+			PR_EXPECT(actuali[0] == inputi[0]);
+		}
+
 		PRUnitTestMethod(DFTAndiDFTTests)
 		{
 			double max_err0 = -99.0, max_err1 = -99.0; //db

--- a/include/pr/common/bit_fields.h
+++ b/include/pr/common/bit_fields.h
@@ -111,9 +111,17 @@ namespace pr
 		return v;
 	}
 
-	// Reverse the order of the lower 'n' bits in 'v'. e.g. ReverseBits32(0b00101101, 4) returns 0b00101011
+	// Reverse the order of the lower 'n' bits in 'v'. n <= 0 returns 'v'; n >= the bit width returns the full reversal.
+	// e.g. ReverseBits32(0b00101101, 4) returns 0b00101011
 	constexpr uint32_t ReverseBits32(uint32_t v, int n)
 	{
+		if (n <= 0)
+			return v;
+
+		if (n >= 32)
+			return ReverseBits32(v);
+
+		// Keep the untouched upper bits, then move the reversed low bits into place.
 		return (v & (0xFFFFFFFFU << n)) | (ReverseBits32(v) >> (32 - n));
 	}
 
@@ -129,9 +137,17 @@ namespace pr
 		return v;
 	}
 
-	// Reverse the order of the lower 'n' bits in 'v'. e.g. ReverseBits32(0b00101101, 4) returns 0b00101011
+	// Reverse the order of the lower 'n' bits in 'v'. n <= 0 returns 'v'; n >= the bit width returns the full reversal.
+	// e.g. ReverseBits32(0b00101101, 4) returns 0b00101011
 	constexpr uint64_t ReverseBits64(uint64_t v, int n)
 	{
+		if (n <= 0)
+			return v;
+
+		if (n >= 64)
+			return ReverseBits64(v);
+
+		// Keep the untouched upper bits, then move the reversed low bits into place.
 		return (v & (0xFFFFFFFFFFFFFFFFULL << n)) | (ReverseBits64(v) >> (64 - n));
 	}
 
@@ -601,6 +617,9 @@ namespace pr::maths
 				auto c = ReverseBits32(a, 8); // just the lower 8 bits
 				auto C = 0b01100011110000011111100011110000U;
 				PR_EXPECT(c == C);
+
+				PR_EXPECT(ReverseBits32(a, 0) == a);
+				PR_EXPECT(ReverseBits32(a, 32) == b);
 			}
 			{            //0123456789_123456789_123456789_123456789_123456789_123456879_123 64bits
 				auto a = 0b0110001111000001111110000000111111110000000001111111111000000000ULL;
@@ -612,6 +631,9 @@ namespace pr::maths
 				auto c = ReverseBits64(a, 12); // just the lower 12 bits
 				auto C = 0b0110001111000001111110000000111111110000000001111111000000000111ULL;
 				PR_EXPECT(c == C);
+
+				PR_EXPECT(ReverseBits64(a, 0) == a);
+				PR_EXPECT(ReverseBits64(a, 64) == b);
 			}
 		}
 		PRUnitTestMethod(IEEEFloats)


### PR DESCRIPTION
Fix ReverseBits32/64(value, n) at the zero and full-width boundaries so the FFT bit-reversal path for length-1 input no longer hits undefined shifts.

Adds direct reverse-bits regression coverage and a dedicated length-1 FFT regression.