### PR TITLE
Fix out-of-bounds read in csv::UnescapeString

### DIFF
--- a/include/pr/storage/csv.h
+++ b/include/pr/storage/csv.h
@@ -131,7 +131,16 @@ namespace pr::csv
 		auto end = ptr + str.size();
 		for (++ptr; ptr != end; ++ptr)
 		{
-			if (*ptr == '"' && *(++ptr) != '"') break;
+			if (*ptr == '"')
+			{
+				// Advance past this quote before testing what follows, so that a quote at the
+				// very end of the string (the normal closing quote) never dereferences one past
+				// 'end'. Reaching 'end', or finding a non-quote character, means this quote closed
+				// the field. A following quote character means this was an escaped literal quote,
+				// so keep it and carry on.
+				if (++ptr == end || *ptr != '"')
+					break;
+			}
 			out.push_back(*ptr);
 		}
 		if (ptr != end) throw std::runtime_error("'csv' string incorrectly escaped");
@@ -429,6 +438,20 @@ namespace pr::storage
 			PR_EXPECT(esc == "\"A \"\"string\"\" with \r\n quotes, commas, and 'new' lines\"");
 			auto ori = UnescapeString(esc);
 			PR_EXPECT(ori == str);
+		}
+		PRUnitTestMethod(UnescapeStringBounds)
+		{
+			using namespace pr::csv;
+
+			// Each of these has its closing quote as the final character of the input, which is
+			// the boundary 'UnescapeString' must handle without reading past the end of the buffer.
+			PR_EXPECT(UnescapeString("\"\"") == "");        // empty field
+			PR_EXPECT(UnescapeString("\"a\"") == "a");      // single character field
+			PR_EXPECT(UnescapeString("\"abc\"") == "abc");  // multi-character field
+			PR_EXPECT(UnescapeString("\"a\"\"\"") == "a\""); // field ending with an escaped quote
+
+			// Characters trailing the closing quote are not valid CSV and should still be rejected.
+			PR_THROWS(UnescapeString("\"a\"x"), std::exception);
 		}
 		PRUnitTestMethod(BasicCSV)
 		{


### PR DESCRIPTION
## Bug

`pr::csv::UnescapeString` in `include/pr/storage/csv.h` had:

```cpp
for (++ptr; ptr != end; ++ptr)
{
    if (*ptr == '"' && *(++ptr) != '"') break;
    out.push_back(*ptr);
}
```

The closing quote of any valid quoted CSV field is always the *last* character of the string. When the loop reaches that closing quote, `*(++ptr)` advances `ptr` to `end` and then **dereferences it**, reading one byte past the end of the buffer.

`pr::string` is explicitly documented as not null-terminated (`include/pr/str/string.h`: "no `c_str()`. That requires null termination which is not guaranteed by this class", `string_traits::null_terminated = false`), so this is a genuine out-of-bounds read, not a harmless read of an implicit terminator.

### Reproduction

Confirmed with AddressSanitizer using a `pr::string` instantiation with `LocalCount = 1` (forcing an exact-capacity heap allocation instead of the default 64-byte local buffer, since the default local buffer masks the issue):

```
==...==ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 1 ...
    #0 UnescapeString ... csv.h:134
0x... is located 0 bytes after 2-byte region [...]
```

Reproduced for `""`, `"a"`, `"abc"`, and strings ending in an escaped quote (`"a"""`) — i.e. every well-formed quoted field, since the closing quote is always the final character.

## Fix

Refactored the pointer advancement so the increment happens first and is checked against `end` before any dereference:

```cpp
if (*ptr == '"')
{
    if (++ptr == end || *ptr != '"')
        break;
}
out.push_back(*ptr);
```

This preserves all existing behaviour:
- Empty/normal quoted fields decode correctly.
- Escaped double-quotes (`""` inside a field) are still unescaped to a single `"`.
- Malformed input with trailing characters after the closing quote (e.g. `"a"x`) still throws `std::runtime_error`.

## Tests

Added `CsvTests::UnescapeStringBounds` covering empty, single-character, multi-character, and escaped-quote-at-end fields, plus the existing malformed-trailing-character rejection.

## Verification

- Reproduced the original OOB read with ASan (heap-buffer-overflow) before the fix, confirmed clean after the fix.
- Built `projects/tests/unittests` in Debug x64 (VS2026, v145 toolset): all 977 unit tests pass, including the new test method.