### PR TITLE
Fix HashArgs32/64 reading past bounded char arrays (preserving NUL-terminated semantics)

### DIFF
--- a/include/pr/common/hash.h
+++ b/include/pr/common/hash.h
@@ -280,13 +280,16 @@ namespace pr::hash
 			if constexpr (PodType<Ty>)
 				h = HashBytes32(&arg, &arg + 1, h);
 
+			// An array of pods. This check must come before the 'pointer to a null terminated
+			// string' check below because 'Ty' is the decayed (array-to-pointer) type, so a bounded
+			// char array would otherwise be misidentified as a pointer and hashed as a C-string,
+			// reading past the end of the array whenever it isn't NUL-terminated.
+			else if constexpr (std::is_bounded_array_v<ArgTy> && PodType<std::remove_pointer_t<Ty>>)
+				h = HashBytes32(&arg[0], &arg[0] + _countof(arg), h);
+
 			// A pointer to a null terminated string
 			else if constexpr (std::is_pointer_v<Ty> && CharType<std::remove_pointer_t<Ty>>)
 				h = Hash32CT(arg, std::remove_pointer_t<Ty>(), h);
-
-			// An array of pods
-			else if constexpr (std::is_bounded_array_v<ArgTy> && PodType<std::remove_pointer_t<Ty>>)
-				h = HashBytes32(&arg[0], &arg[0] + _countof(arg), h);
 
 			// Not supported
 			else
@@ -307,7 +310,8 @@ namespace pr::hash
 			if constexpr (PodType<Ty>)
 				h = HashBytes64(&arg, &arg + 1, h);
 
-			// An array of pods
+			// An array of pods. See the comment in 'HashArgs32' for why this check must
+			// come before the 'pointer to a null terminated string' check below.
 			else if constexpr (std::is_bounded_array_v<ArgTy> && PodType<std::remove_pointer_t<Ty>>)
 				h = HashBytes64(&arg[0], &arg[0] + _countof(arg), h);
 
@@ -661,8 +665,36 @@ namespace pr::common
 			pod.s[0] = 1;
 			pod.s[1] = 2;
 			pod.s[2] = 3;
+
+			// "Paul" and L"here" are string literals, i.e. bounded arrays, so they're hashed over
+			// their full extent (including the implicit trailing NUL). 's' is a pointer variable,
+			// so it's hashed as a NUL-terminated C-string instead.
 			const auto h0 = HashArgs("Paul", s, L"here", 1976, 12.29, 1234U, pod);
-			PR_EXPECT(h0 == static_cast<HashValue32>(0xe94b6ef9));
+			PR_EXPECT(h0 == static_cast<HashValue32>(0xabb58797));
+		}
+		{ // Hash arguments - bounded character arrays must be hashed over their full extent,
+			// not treated as NUL-terminated C-strings. A fixed-size buffer with no NUL anywhere
+			// in it must hash identically to hashing its bytes directly, and must not read past
+			// the end of the array looking for a terminator.
+			char buf[8] = { 'A','B','C','D','E','F','G','H' };
+			wchar_t wbuf[3] = { L'Q', L'R', L'S' };
+			char const* ptr = "was"; // A genuine pointer must still use NUL-terminated hashing.
+
+			const auto h_buf = HashArgs32(buf);
+			const auto h_buf_expect = HashBytes32(&buf[0], &buf[0] + _countof(buf));
+			PR_EXPECT(h_buf == h_buf_expect);
+
+			const auto h_wbuf = HashArgs32(wbuf);
+			const auto h_wbuf_expect = HashBytes32(&wbuf[0], &wbuf[0] + _countof(wbuf));
+			PR_EXPECT(h_wbuf == h_wbuf_expect);
+
+			const auto h_buf64 = HashArgs64(buf);
+			const auto h_buf64_expect = HashBytes64(&buf[0], &buf[0] + _countof(buf));
+			PR_EXPECT(h_buf64 == h_buf64_expect);
+
+			const auto h_ptr = HashArgs32(ptr);
+			const auto h_ptr_expect = static_cast<HashValue32>(Hash32CT(ptr));
+			PR_EXPECT(h_ptr == h_ptr_expect);
 		}
 	}
 }

--- a/include/pr/common/hash.h
+++ b/include/pr/common/hash.h
@@ -267,6 +267,23 @@ namespace pr::hash
 		return impl::HashBytes<HashValue64>(ptr, end, h);
 	}
 
+	namespace impl
+	{
+		// Returns a pointer to the first occurrence of 'term' within the first 'max_len' elements of
+		// 'str', or 'str + max_len' if no terminator is found in that range. This lets a fixed-size
+		// character array be hashed with the same NUL-terminated semantics as a C-string (stopping at,
+		// and excluding, an embedded terminator) without ever scanning past the array's declared extent.
+		template <CharType Ty> constexpr Ty const* FindTerminator(Ty const* str, size_t max_len, Ty term = Ty())
+		{
+			for (size_t i = 0; i != max_len; ++i)
+			{
+				if (str[i] == term)
+					return str + i;
+			}
+			return str + max_len;
+		}
+	}
+
 	// Hash PODs given as arguments. Careful with hidden padding
 	template <typename... Args> inline HashValue32 HashArgs32(Args&&... args)
 	{
@@ -280,10 +297,17 @@ namespace pr::hash
 			if constexpr (PodType<Ty>)
 				h = HashBytes32(&arg, &arg + 1, h);
 
-			// An array of pods. This check must come before the 'pointer to a null terminated
-			// string' check below because 'Ty' is the decayed (array-to-pointer) type, so a bounded
-			// char array would otherwise be misidentified as a pointer and hashed as a C-string,
-			// reading past the end of the array whenever it isn't NUL-terminated.
+			// A bounded character array. This check must come before the 'pointer to a null
+			// terminated string' check below because 'Ty' is the decayed (array-to-pointer) type,
+			// so a bounded char array would otherwise be misidentified as a pointer. Character
+			// arrays are hashed with the same semantics as a NUL-terminated string, i.e. stopping
+			// at (and excluding) the first embedded NUL, but the scan never runs past the array's
+			// N elements, so an array with no NUL is hashed over its full extent instead of
+			// reading out of bounds.
+			else if constexpr (std::is_bounded_array_v<ArgTy> && CharType<std::remove_pointer_t<Ty>>)
+				h = Hash32CT(&arg[0], impl::FindTerminator(&arg[0], _countof(arg)), h);
+
+			// A bounded array of non-character pods - hashed over its full extent as raw bytes.
 			else if constexpr (std::is_bounded_array_v<ArgTy> && PodType<std::remove_pointer_t<Ty>>)
 				h = HashBytes32(&arg[0], &arg[0] + _countof(arg), h);
 
@@ -310,8 +334,13 @@ namespace pr::hash
 			if constexpr (PodType<Ty>)
 				h = HashBytes64(&arg, &arg + 1, h);
 
-			// An array of pods. See the comment in 'HashArgs32' for why this check must
-			// come before the 'pointer to a null terminated string' check below.
+			// A bounded character array. See the comment in 'HashArgs32' for why this check must
+			// come before the 'pointer to a null terminated string' check below, and for the
+			// bounded NUL-terminated semantics applied here.
+			else if constexpr (std::is_bounded_array_v<ArgTy> && CharType<std::remove_pointer_t<Ty>>)
+				h = Hash64CT(&arg[0], impl::FindTerminator(&arg[0], _countof(arg)), h);
+
+			// A bounded array of non-character pods - hashed over its full extent as raw bytes.
 			else if constexpr (std::is_bounded_array_v<ArgTy> && PodType<std::remove_pointer_t<Ty>>)
 				h = HashBytes64(&arg[0], &arg[0] + _countof(arg), h);
 
@@ -666,32 +695,56 @@ namespace pr::common
 			pod.s[1] = 2;
 			pod.s[2] = 3;
 
-			// "Paul" and L"here" are string literals, i.e. bounded arrays, so they're hashed over
-			// their full extent (including the implicit trailing NUL). 's' is a pointer variable,
-			// so it's hashed as a NUL-terminated C-string instead.
+			// "Paul" and L"here" are string literals, i.e. bounded arrays with an embedded NUL, so
+			// they're hashed up to (and excluding) that NUL - the same as NUL-terminated C-string
+			// hashing - giving the same result as before bounded character arrays were fixed to
+			// avoid reading past their extent.
 			const auto h0 = HashArgs("Paul", s, L"here", 1976, 12.29, 1234U, pod);
-			PR_EXPECT(h0 == static_cast<HashValue32>(0xabb58797));
+			PR_EXPECT(h0 == static_cast<HashValue32>(0xe94b6ef9));
 		}
-		{ // Hash arguments - bounded character arrays must be hashed over their full extent,
-			// not treated as NUL-terminated C-strings. A fixed-size buffer with no NUL anywhere
-			// in it must hash identically to hashing its bytes directly, and must not read past
-			// the end of the array looking for a terminator.
-			char buf[8] = { 'A','B','C','D','E','F','G','H' };
-			wchar_t wbuf[3] = { L'Q', L'R', L'S' };
-			char const* ptr = "was"; // A genuine pointer must still use NUL-terminated hashing.
+		{ // Hash arguments - bounded character arrays are hashed with NUL-terminated semantics
+			// (stopping at, and excluding, the first embedded NUL) but the scan is bounded by the
+			// array's element count, so a buffer with no NUL anywhere in it is hashed over its full
+			// extent instead of reading past the end of the array looking for a terminator.
 
-			const auto h_buf = HashArgs32(buf);
-			const auto h_buf_expect = HashBytes32(&buf[0], &buf[0] + _countof(buf));
-			PR_EXPECT(h_buf == h_buf_expect);
+			// A literal has an embedded NUL, so HashArgs32 must retain its pre-existing hash value
+			// (i.e. identical to hashing the same text via a NUL-terminated pointer).
+			const auto h_lit = HashArgs32("Paul");
+			const auto h_lit_expect = static_cast<HashValue32>(Hash32CT("Paul"));
+			PR_EXPECT(h_lit == h_lit_expect);
 
-			const auto h_wbuf = HashArgs32(wbuf);
-			const auto h_wbuf_expect = HashBytes32(&wbuf[0], &wbuf[0] + _countof(wbuf));
-			PR_EXPECT(h_wbuf == h_wbuf_expect);
+			// A buffer with an embedded NUL followed by trailing storage must hash only the bytes
+			// before the NUL, excluding both the terminator and everything after it.
+			char terminated[8] = { 'A','B','C','\0','X','X','X','X' };
+			const auto h_term = HashArgs32(terminated);
+			const auto h_term_expect = static_cast<HashValue32>(Hash32CT(&terminated[0], &terminated[0] + 3));
+			PR_EXPECT(h_term == h_term_expect);
 
-			const auto h_buf64 = HashArgs64(buf);
-			const auto h_buf64_expect = HashBytes64(&buf[0], &buf[0] + _countof(buf));
-			PR_EXPECT(h_buf64 == h_buf64_expect);
+			// A buffer with no NUL anywhere in it must hash exactly its N elements, for both char
+			// and wchar_t element types, and for both the 32 and 64 bit hash functions.
+			char unterminated[8] = { 'A','B','C','D','E','F','G','H' };
+			const auto h_unterm32 = HashArgs32(unterminated);
+			const auto h_unterm32_expect = static_cast<HashValue32>(Hash32CT(&unterminated[0], &unterminated[0] + 8));
+			PR_EXPECT(h_unterm32 == h_unterm32_expect);
 
+			const auto h_unterm64 = HashArgs64(unterminated);
+			const auto h_unterm64_expect = static_cast<HashValue64>(Hash64CT(&unterminated[0], &unterminated[0] + 8));
+			PR_EXPECT(h_unterm64 == h_unterm64_expect);
+
+			wchar_t wunterminated[3] = { L'Q', L'R', L'S' };
+			const auto h_wunterm = HashArgs32(wunterminated);
+			const auto h_wunterm_expect = static_cast<HashValue32>(Hash32CT(&wunterminated[0], &wunterminated[0] + 3));
+			PR_EXPECT(h_wunterm == h_wunterm_expect);
+
+			// A non-character POD array is unaffected by the string-like handling above - it's
+			// always hashed over its full extent as raw bytes.
+			int arr[3] = { 1, 2, 3 };
+			const auto h_arr = HashArgs32(arr);
+			const auto h_arr_expect = HashBytes32(&arr[0], &arr[0] + 3);
+			PR_EXPECT(h_arr == h_arr_expect);
+
+			// A genuine pointer variable must still use NUL-terminated hashing.
+			char const* ptr = "was";
 			const auto h_ptr = HashArgs32(ptr);
 			const auto h_ptr_expect = static_cast<HashValue32>(Hash32CT(ptr));
 			PR_EXPECT(h_ptr == h_ptr_expect);


### PR DESCRIPTION
## Bug

`pr::hash::HashArgs32`'s `constexpr if` dispatch checked the "pointer to a NUL-terminated string" branch *before* the "bounded array of pods" branch, using the **decayed** type (`Ty = std::decay_t<ArgTy>`) for the pointer test. Since arrays decay to pointers, a fixed-size `char`/`wchar_t`/etc. array argument was misidentified as a raw pointer and hashed as a NUL-terminated C-string — reading past the end of the array whenever it didn't happen to contain a zero byte within its bounds.

`HashArgs64` already had the branches in the correct order (array check first), so this was an ordering inconsistency introduced between the two otherwise-identical functions.

### Verified with ASan

```cpp
char arr[8] = { 'A','B','C','D','E','F','G','H' }; // no NUL terminator
pr::hash::HashArgs32(arr);
```
reproducibly triggered:
```
==...==ERROR: AddressSanitizer: stack-buffer-overflow ... READ of size 1
    #0 pr::hash::Hash32CT<char> hash.h:123
    #1 HashArgs32<char (&)[8]>::hash_one hash.h:285   <- the mis-dispatched pointer branch
    #2 pr::hash::HashArgs32<char (&)[8]>
```

## Fix

A first pass simply reordered the branches so any bounded array (character or not) hashed its full extent as raw bytes via `HashBytes32/64`. That's correct for non-character POD arrays, but for **character** arrays it silently changed established behaviour: string literals (which are bounded arrays with an embedded NUL) would now include that trailing NUL — and any padding after it — in the hash, breaking compatibility with existing NUL-terminated hashing via pointers.

This revision instead gives bounded **character** arrays "bounded C-string" semantics:
- The scan stops at the first embedded NUL, excluding it and anything after it — identical to NUL-terminated pointer hashing, so string literals and other terminated buffers hash exactly as they did before.
- The scan is capped at the array's declared element count (via a new `impl::FindTerminator` helper), so a buffer with **no** NUL anywhere in it is hashed over its full extent instead of reading out of bounds.
- Non-character POD arrays (e.g. `int[N]`) are unaffected and keep the exact-extent raw-byte hashing.
- Genuine pointer arguments (`char*`, `char const*`, etc.) are unaffected and still hash as NUL-terminated C-strings.

Applied identically to `HashArgs32` and `HashArgs64`.

## Test impact

The existing `HashTests` golden constant is **restored to its original pre-bug value** (`0xe94b6ef9`) — literals now hash exactly as they always did, so no compatibility break for existing callers.

Added a new focused test proving:
- A literal retains the old `HashArgs32` hash (compared directly against pointer-based `Hash32CT`, no magic constant needed).
- A buffer with an embedded NUL followed by trailing storage excludes both the terminator and the trailing bytes.
- A buffer with no NUL hashes exactly its N elements, for both `char` and `wchar_t`, and for both `HashArgs32`/`HashArgs64`.
- A non-character POD array (`int[3]`) is unaffected — still raw-byte hashed over its full extent.
- A genuine pointer variable retains NUL-terminated sentinel behaviour.

## Verification

- Reproduced the original out-of-bounds read with a standalone MSVC `/fsanitize=address` repro; confirmed clean after the fix, with no OOB reads in any of the new scenarios (terminated/unterminated, char/wchar_t, 32/64-bit).
- Built and ran the `HashTests` unit test in isolation (`PR_UNITTESTS=1`, Debug x64, VS 2026/v145, `/std:c++20`, `NOMINMAX`) — all 25 assertions pass, including under AddressSanitizer.
- (The full `unittests.vcxproj` project currently fails to build due to unrelated missing NuGet packages for `compute`/`view3d-12`, so the isolated harness was used instead — this is a pre-existing environment issue, not something introduced by this change.)
