### PR TITLE
Fix missed-wakeup race in ThreadPool condition-variable notifications

### DIFF
--- a/include/pr/threads/thread_pool.h
+++ b/include/pr/threads/thread_pool.h
@@ -46,8 +46,18 @@ namespace pr::threads
 		}
 		~ThreadPool()
 		{
-			m_shutdown = true;
+			// 'm_shutdown' is part of the predicate that worker threads wait on via 'm_cv_task_added'
+			// (see 'ThreadMain'). The predicate must only change while 'm_mutex_tasks' is held: a
+			// worker can otherwise observe the old value of 'm_shutdown' with the lock held, and then
+			// have this thread flip it and call 'notify_all' before the worker's 'wait' call has
+			// actually unlocked and registered with the condition variable. That notification would
+			// then be missed, leaving the worker blocked forever and this destructor hung on 'join'.
+			{
+				std::lock_guard<std::mutex> lock(m_mutex_tasks);
+				m_shutdown = true;
+			}
 			m_cv_task_added.notify_all();
+
 			for (auto& thread : m_threads)
 			{
 				if (thread.joinable())
@@ -64,8 +74,17 @@ namespace pr::threads
 		// Queue a task with no return value
 		void QueueTask(std::function<void()>&& task)
 		{
-			++m_tasks_pending;
-			m_tasks.push(std::move(task));
+			// 'm_tasks_pending' and the queue contents are the predicate state for 'm_cv_task_complete'
+			// and 'm_cv_task_added' respectively (see 'WaitAll' and 'ThreadMain'). Both must change while
+			// 'm_mutex_tasks' is held, otherwise a waiter could check the predicate (false, lock held),
+			// then this thread could update the state and call 'notify' before the waiter's 'wait' call
+			// unlocks and registers with the condition variable - a missed wakeup that leaves the waiter
+			// blocked until some unrelated notification happens to come along, or forever.
+			{
+				std::lock_guard<std::mutex> lock(m_mutex_tasks);
+				++m_tasks_pending;
+				m_tasks.push(std::move(task));
+			}
 			m_cv_task_added.notify_one();
 		}
 
@@ -112,9 +131,15 @@ namespace pr::threads
 				// Execute the task
 				task();
 
-				// Signal task completed
-				--m_tasks_pending;
-				assert(m_tasks_pending >= 0);
+				// Signal task completed. The decrement must happen while 'm_mutex_tasks' is held for
+				// the same reason as in 'QueueTask': 'm_tasks_pending' is the predicate state for
+				// 'm_cv_task_complete' (see 'WaitAll'), and changing it without the lock held would
+				// allow a waiter's predicate check to race with this update, missing the notification.
+				{
+					std::lock_guard<std::mutex> lock(m_mutex_tasks);
+					--m_tasks_pending;
+					assert(m_tasks_pending >= 0);
+				}
 				m_cv_task_complete.notify_all();
 			}
 		}
@@ -128,26 +153,37 @@ namespace pr::threads
 {
 	PRUnitTest(ThreadPoolTests)
 	{
-#if 0 // There is a race condition in here somewhere. This test sometimes never ends
-		ThreadPool pool;
-		std::atomic_int count = 0;
+		using namespace std::chrono_literals;
+
+		// 'pool' is heap-allocated via 'shared_ptr' and shared with the detached thread below so
+		// that, if a regression reintroduces the missed-wakeup bug and 'WaitAll' hangs, the pool
+		// object stays alive for that thread instead of being destroyed while still in use.
+		auto pool = std::make_shared<ThreadPool>();
+		auto count = std::make_shared<std::atomic_int>(0);
 
 		for (int i = 0; i != 10; ++i)
 		{
-			pool.QueueTask([&]
+			pool->QueueTask([count]
 			{
-				++count;
+				++*count;
 				std::this_thread::sleep_for(std::chrono::milliseconds(100));
-				++count;
+				++*count;
 			});
 		}
 
-		pool.WaitAll();
-		PR_EXPECT(count == 20);
+		// Run 'WaitAll' on a detached thread and signal completion via a promise. Unlike a
+		// 'std::async' future, a 'std::promise'-backed future doesn't block in its destructor, so a
+		// timed-out wait here reports a test failure without risking a further hang (see
+		// 'ThreadPoolMissedWakeupStressTest' for the race this guards against).
+		auto done = std::make_shared<std::promise<void>>();
+		auto done_future = done->get_future();
+		std::thread([pool, done] { pool->WaitAll(); done->set_value(); }).detach();
+
+		PR_EXPECT(done_future.wait_for(5s) == std::future_status::ready);
+		PR_EXPECT(*count == 20);
 
 	//	auto result = pool.QueueTaskR([] { std::this_thread::sleep_for(std::chrono::milliseconds(100)); return 42; });
 	//	PR_EXPECT(result.get() == 42);
-#endif
 	}
 
 	// Regression test for a bug where a completed task could be re-run: the worker loop kept a
@@ -189,6 +225,84 @@ namespace pr::threads
 		pool.WaitAll();
 		PR_EXPECT(count_a == 1);
 		PR_EXPECT(count_b == 1);
+	}
+
+	// Regression test for a missed-wakeup race: the state that condition-variable predicates depend
+	// on ('m_tasks_pending' and the task queue contents) must only change while 'm_mutex_tasks' is
+	// held. Otherwise, a waiter in 'WaitAll' can check its predicate (false, lock held), and then have
+	// 'QueueTask' or the worker's completion update race ahead and notify before the waiter's 'wait'
+	// call has actually unlocked and registered with the condition variable - a missed notification
+	// that leaves 'WaitAll' blocked forever. Queuing tasks from several producer threads concurrently
+	// with workers draining the queue, repeated many times, makes that race window likely to be hit
+	// if it still exists.
+	PRUnitTest(ThreadPoolMissedWakeupStressTest)
+	{
+		using namespace std::chrono_literals;
+
+		for (int rep = 0; rep != 200; ++rep)
+		{
+			// Heap-allocated and shared with the detached 'WaitAll' thread below so that, if this
+			// regresses and 'WaitAll' hangs, the pool stays alive for that thread (and is
+			// intentionally never destroyed) instead of the test blocking to tear it down.
+			auto pool = std::make_shared<ThreadPool>(4);
+			auto count = std::make_shared<std::atomic_int>(0);
+
+			std::vector<std::thread> producers;
+			for (int p = 0; p != 4; ++p)
+			{
+				producers.push_back(std::thread([pool, count]
+				{
+					for (int i = 0; i != 25; ++i)
+						pool->QueueTask([count] { ++*count; });
+				}));
+			}
+			for (auto& producer : producers)
+				producer.join();
+
+			// See 'ThreadPoolTests' for why a promise-backed future (rather than 'std::async') is
+			// used here: its destructor doesn't block, so a timed-out wait can't itself hang.
+			auto done = std::make_shared<std::promise<void>>();
+			auto done_future = done->get_future();
+			std::thread([pool, done] { pool->WaitAll(); done->set_value(); }).detach();
+
+			auto status = done_future.wait_for(5s);
+			PR_EXPECT(status == std::future_status::ready);
+			if (status != std::future_status::ready)
+				break; // Regression detected: stop repeating rather than leak an unbounded number of stuck threads.
+
+			PR_EXPECT(*count == 100);
+		}
+	}
+
+	// Regression test for a missed-wakeup race in pool shutdown: 'm_shutdown' must only change while
+	// 'm_mutex_tasks' is held, otherwise a worker parked in 'wait' on 'm_cv_task_added' can miss the
+	// shutdown notification and never return, leaving the destructor's 'join' calls blocked forever.
+	// Constructing and immediately destroying pools with idle workers (no tasks queued, so workers are
+	// parked in 'wait' when shutdown happens), repeated many times, makes that race window likely to
+	// be hit if it still exists.
+	PRUnitTest(ThreadPoolShutdownStressTest)
+	{
+		using namespace std::chrono_literals;
+
+		for (int rep = 0; rep != 200; ++rep)
+		{
+			// The pool is constructed and destroyed entirely within the detached thread, so a hung
+			// destructor (were the bug to regress) leaks only that thread rather than risking
+			// use of a pool object whose enclosing test scope has already returned.
+			auto done = std::make_shared<std::promise<void>>();
+			auto done_future = done->get_future();
+			std::thread([done]
+			{
+				ThreadPool pool(4);
+				std::this_thread::sleep_for(1ms); // Give workers a chance to reach 'wait' before destruction.
+				done->set_value();
+			}).detach();
+
+			auto status = done_future.wait_for(5s);
+			PR_EXPECT(status == std::future_status::ready);
+			if (status != std::future_status::ready)
+				break; // Regression detected: stop repeating rather than leak an unbounded number of stuck threads.
+		}
 	}
 }
 #endif

--- a/include/pr/threads/thread_pool.h
+++ b/include/pr/threads/thread_pool.h
@@ -288,13 +288,18 @@ namespace pr::threads
 		{
 			// The pool is constructed and destroyed entirely within the detached thread, so a hung
 			// destructor (were the bug to regress) leaks only that thread rather than risking
-			// use of a pool object whose enclosing test scope has already returned.
+			// use of a pool object whose enclosing test scope has already returned. 'pool' is
+			// scoped to end before 'set_value' is called, so the promise is only fulfilled once
+			// the destructor (and its worker 'join' calls) has actually completed - otherwise a
+			// hung destructor would go undetected, since 'set_value' would already have fired.
 			auto done = std::make_shared<std::promise<void>>();
 			auto done_future = done->get_future();
 			std::thread([done]
 			{
-				ThreadPool pool(4);
-				std::this_thread::sleep_for(1ms); // Give workers a chance to reach 'wait' before destruction.
+				{
+					ThreadPool pool(4);
+					std::this_thread::sleep_for(1ms); // Give workers a chance to reach 'wait' before destruction.
+				}
 				done->set_value();
 			}).detach();
 


### PR DESCRIPTION
## Root cause

`include/pr/threads/thread_pool.h` had three places that mutated state used by a condition-variable predicate and then called `notify_one()`/`notify_all()` **without holding `m_mutex_tasks`**:

- The destructor set `m_shutdown = true` unlocked (predicate for `m_cv_task_added` in `ThreadMain`).
- `QueueTask` incremented `m_tasks_pending` and pushed onto the queue unlocked (predicate for `m_cv_task_added`).
- `ThreadMain` decremented `m_tasks_pending` unlocked after running a task (predicate for `m_cv_task_complete` in `WaitAll`).

`condition_variable::wait(lock, pred)` is only safe against missed wakeups if every mutation to state that `pred` reads happens while holding the *same* mutex as the waiter. When a notifier mutates state and notifies without ever taking that mutex, there is a race window between the waiter's `pred()` check (false, lock held) and the waiter's `wait()` call actually unlocking and registering with the CV. If the notifier's mutate+notify happens in that window, the notification is lost — `WaitAll()` or the destructor's `thread::join()` can then block forever. This matches the comment on the previously-disabled `ThreadPoolTests` about intermittent hangs, and is distinct from the already-fixed stale-task-replay bug.

## Fix

Hold `m_mutex_tasks` while mutating the predicate state in the destructor, `QueueTask`, and `ThreadMain`'s task-complete decrement. The `notify_*()` calls stay outside the lock (standard practice — avoids waking a thread only to have it immediately block on the mutex); only the mutation needs to be lock-protected.

## Tests

- Re-enabled `ThreadPoolTests` (previously `#if 0`'d out due to intermittent hangs), adapted to run on a detached thread guarded by a `promise`/`future` timeout so a regression fails the test instead of hanging the test process.
- Added `ThreadPoolMissedWakeupStressTest` (200 reps, 4 producer threads × 25 tasks, timeout-guarded `WaitAll`).
- Added `ThreadPoolShutdownStressTest` (200 reps of pool construct/destroy with idle workers, timeout-guarded). **Fixed in a follow-up commit**: the promise's `set_value()` was originally called from the same lambda scope as the local `ThreadPool`, i.e. *before* its destructor ran, so the timeout guard wasn't actually watching destructor/shutdown completion. `pool` is now in an inner scope so `set_value()` only fires after the destructor (and its `join` calls) has completed.
- Note: a `std::async`-launched `future`'s destructor blocks until the task completes even after `wait_for` times out, which would defeat a timeout guard — these tests instead use a detached `std::thread` + `std::promise`, with `shared_ptr` ownership so a genuine hang leaks the pool/thread rather than blocking or dangling. Confirmed no detached thread in any test captures stack-owned state (all captures are `shared_ptr`, and `ThreadPoolShutdownStressTest`'s `ThreadPool` is fully owned by its own detached thread).

## Verification

This worktree's native dependencies (physics/view3d-12/lua static libs, NuGet-restored DXC/PIX runtime DLLs) weren't present, so a full solution build wasn't practical for this self-contained header change. Instead, verified directly:

- Compiled `thread_pool.h` + `pr/common/unittests.h` standalone with the VS2026 v145 toolset using this project's actual Debug/x64 preprocessor settings from `build/props/root.props` (`NOMINMAX`, `WIN32_LEAN_AND_MEAN`, `_WIN32_WINNT_WIN10`, `_DEBUG`, `_ITERATOR_DEBUG_LEVEL=1`, `/std:c++20 /Zc:__cplusplus /EHsc /W4 /MDd`). All 4 tests pass reliably across 15 consecutive full runs (~3.5s each).
- Confirmed the fix is meaningful: reverting the three synchronization changes in a throwaway copy did not reproduce a failure at normal timing granularity (the race window is narrow), so I additionally widened the race window (injecting a small delay between the predicate check and the actual `wait()` call in throwaway copies of `WaitAll` and `ThreadMain`) to make it deterministic. With a fix reverted and the corresponding window widened, the test suite correctly reports a clean failure (not a process hang) for both the `WaitAll`/task path and the shutdown/destructor path. With the real fix in place, the same widened-window harnesses still pass.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
