### PR TITLE
Fix SpinLock recursion prematurely releasing the outer critical section

### DIFF
--- a/include/pr/threads/spin_lock.h
+++ b/include/pr/threads/spin_lock.h
@@ -20,11 +20,14 @@ namespace pr
 {
 	namespace threads
 	{
-		// Use with std::lock_guard<SpinLock>
+		// Use with std::lock_guard<SpinLock>. Recursive: lock()/try_lock() succeed immediately when
+		// called again by the thread that already owns the lock, and the lock is only released once
+		// unlock() has been called once for each successful lock()/try_lock() call on that thread.
 		class SpinLock
 		{
 			std::atomic_bool m_flag;
 			std::atomic<std::thread::id> m_owner; // Must be atomic to avoid data race with concurrent lock/unlock
+			int m_depth; // Recursion depth. Only ever read or written by the thread that currently owns the lock.
 			#if PR_STACKTRACE
 			std::string m_stack; // call stack when last locked
 			#endif
@@ -36,8 +39,9 @@ namespace pr
 				if (m_flag.exchange(true) != 0)
 					return false;
 
-				// Save the lock owner
+				// Save the lock owner and reset the recursion depth to the outer-most level
 				m_owner.store(std::this_thread::get_id());
+				m_depth = 1;
 
 				// Record the call stack when the lock is acquired
 				#if PR_STACKTRACE
@@ -58,13 +62,17 @@ namespace pr
 			SpinLock()
 				:m_flag()
 				,m_owner()
+				,m_depth()
 			{}
 
 			void lock()
 			{
-				// Already locked by this thread?
+				// Already locked by this thread? Re-entrant acquisition, so just record the extra level.
 				if (std::this_thread::get_id() == m_owner.load())
+				{
+					++m_depth;
 					return;
+				}
 
 				// Spin lock. This works because exchange() returns the previous
 				// value, the loop exits when the previous value was false.
@@ -74,9 +82,12 @@ namespace pr
 
 			bool try_lock()
 			{
-				// Already locked by this thread?
+				// Already locked by this thread? Re-entrant acquisition, so just record the extra level.
 				if (std::this_thread::get_id() == m_owner.load())
+				{
+					++m_depth;
 					return true;
+				}
 
 				// exchange() returns the previous value, so the lock is
 				// acquired when the previous value was false.
@@ -85,6 +96,12 @@ namespace pr
 
 			void unlock()
 			{
+				// Only release ownership once every nested lock()/try_lock() call on this thread has
+				// been matched by an unlock(), otherwise an inner unlock() would expose an outer
+				// critical section that is still in progress on this thread.
+				if (--m_depth != 0)
+					return;
+
 				m_owner.store(std::thread::id());
 				m_flag.exchange(false);
 			}
@@ -154,6 +171,78 @@ namespace pr::threads
 
 		PR_EXPECT(thing.m_count == 0);
 		PR_EXPECT(thing.m_calls >= 100);
+	}
+	PRUnitTest(SpinLockRecursionTests)
+	{
+		// Same-thread re-entrant locking must not release the lock until the outer-most unlock.
+		SpinLock lock;
+		std::atomic_bool outer_locked(false);
+		std::atomic_bool contender_saw_locked(false);
+		std::atomic_bool contender_done(false);
+
+		// A second thread that reports whether the lock is still held once the owning
+		// thread signals it has completed a nested lock/unlock pair within the outer scope.
+		std::thread contender([&]
+		{
+			while (!outer_locked.load())
+				std::this_thread::yield();
+
+			contender_saw_locked.store(!lock.try_lock());
+			contender_done.store(true);
+		});
+
+		{
+			std::lock_guard<SpinLock> outer(lock);
+			{
+				// Recursive re-entry from the owning thread; this must not release the outer lock.
+				std::lock_guard<SpinLock> inner(lock);
+			}
+
+			outer_locked.store(true);
+			while (!contender_done.load())
+				std::this_thread::yield();
+		}
+		contender.join();
+
+		// The nested unlock must not have exposed the outer critical section.
+		PR_EXPECT(contender_saw_locked.load());
+
+		// After the outer scope exits, the lock must be fully released.
+		PR_EXPECT(lock.try_lock());
+		lock.unlock();
+	}
+	PRUnitTest(SpinLockRecursionDepthTests)
+	{
+		// Multiple levels of recursion must all be unwound before the lock is released.
+		// try_lock() from the owning thread always succeeds (it is the same recursive re-entry),
+		// so ownership is probed here from a second thread instead, for which try_lock() only
+		// succeeds once the outer-most owning thread has fully unwound its recursion. Results are
+		// captured via atomics and asserted on the main thread; PR_EXPECT throws on failure, and an
+		// exception escaping a std::thread function would call std::terminate.
+		SpinLock lock;
+		lock.lock();
+		lock.lock();
+		lock.lock();
+
+		lock.unlock();
+		lock.unlock();
+
+		std::atomic_bool probe1_locked_out(false);
+		std::thread probe1([&] { probe1_locked_out.store(!lock.try_lock()); });
+		probe1.join();
+		PR_EXPECT(probe1_locked_out.load());
+
+		lock.unlock();
+
+		std::atomic_bool probe2_acquired(false);
+		std::thread probe2([&]
+		{
+			probe2_acquired.store(lock.try_lock());
+			if (probe2_acquired.load())
+				lock.unlock();
+		});
+		probe2.join();
+		PR_EXPECT(probe2_acquired.load());
 	}
 }
 #endif


### PR DESCRIPTION
## Bug

`pr::threads::SpinLock` (`include/pr/threads/spin_lock.h`) treats a same-thread re-entrant `lock()`/`try_lock()` call as an immediate success (recursive semantics — that's clearly the intent of the `if (std::this_thread::get_id() == m_owner.load()) ...` check in both), but had no recursion depth counter. `unlock()` unconditionally cleared `m_owner`/`m_flag` regardless of nesting level.

Consequence: with a nested `std::lock_guard<SpinLock>`, the **inner** `unlock()` releases the lock entirely, exposing the **outer** critical section to other threads while the outer scope is still active — a real thread-safety violation.

```cpp
std::lock_guard<SpinLock> outer(lock);
{
    std::lock_guard<SpinLock> inner(lock); // recursive re-entry "succeeds"
} // inner's destructor calls unlock(), which fully releases the lock here!
// ... outer critical section continues, but the lock is not actually held ...
```

No other callers of `SpinLock` exist in the codebase currently (only its own unit test), so this fixes the class's own documented recursive contract rather than an external regression.

## Fix

Added `m_depth`, a plain `int` recursion counter only ever touched by the thread that currently owns the lock:
- `try_lock_internal()` initializes `m_depth = 1` when the lock is first acquired.
- `lock()`/`try_lock()` increment `m_depth` on same-thread re-entry instead of just returning.
- `unlock()` only clears `m_owner`/`m_flag` once `m_depth` reaches `0`, i.e. once every nested `lock()`/`try_lock()` call has been matched by an `unlock()`.

## Tests

Added two deterministic tests to the existing `PR_UNITTESTS` block in `spin_lock.h`:
- `SpinLockRecursionTests`: nested `lock_guard` on the owning thread, with a second thread attempting `try_lock()` before the outer scope ends — verifies the lock is still held for the second thread, then verifies it's fully released after the outer scope exits.
- `SpinLockRecursionDepthTests`: three levels of manual `lock()`/`unlock()`, verified via a second thread's `try_lock()` at each unwind stage.

Both tests reproduced the bug prior to the fix (assertion failures, not crashes — thread-spawned assertions are done via atomics and asserted back on the main thread, since `PR_EXPECT` throws and an exception escaping a `std::thread` function would call `std::terminate`).

## Verification

- Built `unittests.vcxproj` in Debug x64 (VS 2026, v145 toolset).
- Full suite: `**** UnitTest results: All 983 unit tests passed. ****`
- Ran the two new tests (filtered) 300 times in a tight loop with zero failures, to rule out timing flakiness.