### PR TITLE
Fix undefined-behaviour shifts in 3D space-filling curve encoders

### DIFF
--- a/include/pr/algorithm/space_filling.h
+++ b/include/pr/algorithm/space_filling.h
@@ -61,31 +61,40 @@ namespace pr::space_filling
 	// The 3D "]"-Order and Z-Order curves below interleave 3 bits per fractal level (one bit from
 	// each of x, y, z) into a single 64-bit index. Only floor(64/3) = 21 fractal levels fit before
 	// a per-level shift would reach or exceed the 64-bit width of the index, so each axis can only
-	// contribute 21 bits to the curve. Negative coordinates are supported by biasing each axis into
-	// the unsigned range [0, 2^C_Bits3D) before interleaving, and un-biasing again after extraction,
-	// rather than relying on signed integer overflow (which is undefined behaviour).
+	// contribute 21 bits to the curve. Each axis is therefore treated as a 21-bit two's-complement
+	// value: encoding masks the axis down to its low C_Bits3D bits (the same bits used by the
+	// existing, unchanged 2's-complement mapping for small magnitudes), and decoding sign-extends
+	// bit (C_Bits3D - 1) back out. This preserves index 0 <-> the origin and every other existing
+	// low-magnitude index <-> point mapping exactly, while adding support for the full 21-bit
+	// range in both directions. All bit manipulation below uses uint64_t so shifts are always
+	// well-defined; the signed int64_t/int32_t API types are only used at the function boundary.
 	inline static constexpr int C_Bits3D = 8 * sizeof(int64_t) / 3; // 21 bits per axis (63 of the 64 index bits used)
-	inline static constexpr int32_t C_Bias3D = int32_t{1} << (C_Bits3D - 1); // 2^20, centres the representable range on the origin
+	inline static constexpr int32_t C_Bias3D = int32_t{1} << (C_Bits3D - 1); // 2^20, magnitude of the representable range either side of zero
+	inline static constexpr uint64_t C_Mask3D = (uint64_t{1} << C_Bits3D) - 1; // low C_Bits3D bits
+
+	// Sign-extend the low C_Bits3D bits of 'v' (all other bits must be zero) to a signed 32-bit value.
+	inline constexpr int32_t SignExtend3D(uint64_t v)
+	{
+		constexpr uint64_t sign_bit = uint64_t{1} << (C_Bits3D - 1);
+		return static_cast<int32_t>((v ^ sign_bit) - sign_bit);
+	}
 
 	// Convert a ]-Order 3D index to a 3D point.
 	// Only the low (3 * C_Bits3D) bits of 'index' are meaningful; higher bits are ignored. The
 	// reconstructed point's axes are each in the range [-C_Bias3D, C_Bias3D - 1].
 	inline iv4 COrder3D(int64_t index)
 	{
-		int64_t x = 0, y = 0, z = 0;
+		auto idx = static_cast<uint64_t>(index);
+		uint64_t x = 0, y = 0, z = 0;
 		for (int i = 0; i != C_Bits3D; ++i)
 		{
-			auto oct = C_Order3DFwd[index & 0b111]; // oct we're in
-			x += (1LL << i) * ((oct >> 0) & 1); // += points/oct/axis at this level
-			y += (1LL << i) * ((oct >> 1) & 1);
-			z += (1LL << i) * ((oct >> 2) & 1);
-			index >>= 3;
+			auto oct = C_Order3DFwd[idx & 0b111]; // oct we're in
+			x |= static_cast<uint64_t>((oct >> 0) & 1) << i; // set the bit/axis at this level
+			y |= static_cast<uint64_t>((oct >> 1) & 1) << i;
+			z |= static_cast<uint64_t>((oct >> 2) & 1) << i;
+			idx >>= 3;
 		}
-		return iv4(
-			static_cast<int32_t>(x - C_Bias3D),
-			static_cast<int32_t>(y - C_Bias3D),
-			static_cast<int32_t>(z - C_Bias3D),
-			1);
+		return iv4(SignExtend3D(x), SignExtend3D(y), SignExtend3D(z), 1);
 	}
 
 	// Convert a 3D point to an index in the "]" Order 3D space filling curve.
@@ -97,11 +106,12 @@ namespace pr::space_filling
 		assert(pt.y >= -C_Bias3D && pt.y < C_Bias3D && "COrder3D: y coordinate outside the representable 21-bit range");
 		assert(pt.z >= -C_Bias3D && pt.z < C_Bias3D && "COrder3D: z coordinate outside the representable 21-bit range");
 
-		int64_t x = pt.x + C_Bias3D;
-		int64_t y = pt.y + C_Bias3D;
-		int64_t z = pt.z + C_Bias3D;
+		// Truncate each axis to its low C_Bits3D bits (the two's-complement representation of the value).
+		uint64_t x = static_cast<uint32_t>(pt.x) & C_Mask3D;
+		uint64_t y = static_cast<uint32_t>(pt.y) & C_Mask3D;
+		uint64_t z = static_cast<uint32_t>(pt.z) & C_Mask3D;
 
-		int64_t index = 0;
+		uint64_t index = 0;
 		for (int i = 0; i != C_Bits3D; ++i)
 		{
 			auto oct =
@@ -109,12 +119,12 @@ namespace pr::space_filling
 				((y & 1) << 1) |
 				((z & 1) << 2);
 
-			index += C_Order3DInv[oct] * (1LL << (3 * i)); // safe: 3*i <= 3*(C_Bits3D - 1) = 60 < 64
+			index |= static_cast<uint64_t>(C_Order3DInv[oct]) << (3 * i); // safe: 3*i <= 3*(C_Bits3D - 1) = 60 < 64
 			x >>= 1;
 			y >>= 1;
 			z >>= 1;
 		}
-		return index;
+		return static_cast<int64_t>(index);
 	}
 
 
@@ -151,18 +161,15 @@ namespace pr::space_filling
 	// reconstructed point's axes are each in the range [-C_Bias3D, C_Bias3D - 1].
 	inline iv4 ZOrder3D(int64_t index)
 	{
-		int64_t x = 0, y = 0, z = 0;
+		auto idx = static_cast<uint64_t>(index);
+		uint64_t x = 0, y = 0, z = 0;
 		for (int i = 0; i != C_Bits3D; ++i)
 		{
-			x |= (index & (1LL << (3 * i + 0))) >> (2 * i + 0); // safe: 3*i <= 60, 2*i <= 40
-			y |= (index & (1LL << (3 * i + 1))) >> (2 * i + 1);
-			z |= (index & (1LL << (3 * i + 2))) >> (2 * i + 2);
+			x |= (idx & (uint64_t{1} << (3 * i + 0))) >> (2 * i + 0); // safe: 3*i <= 60, 2*i <= 40
+			y |= (idx & (uint64_t{1} << (3 * i + 1))) >> (2 * i + 1);
+			z |= (idx & (uint64_t{1} << (3 * i + 2))) >> (2 * i + 2);
 		}
-		return iv4(
-			static_cast<int32_t>(x - C_Bias3D),
-			static_cast<int32_t>(y - C_Bias3D),
-			static_cast<int32_t>(z - C_Bias3D),
-			1);
+		return iv4(SignExtend3D(x), SignExtend3D(y), SignExtend3D(z), 1);
 	}
 
 	// Convert a 3D point to an index in the Z-Order 3D space filling curve.
@@ -174,18 +181,19 @@ namespace pr::space_filling
 		assert(pt.y >= -C_Bias3D && pt.y < C_Bias3D && "ZOrder3D: y coordinate outside the representable 21-bit range");
 		assert(pt.z >= -C_Bias3D && pt.z < C_Bias3D && "ZOrder3D: z coordinate outside the representable 21-bit range");
 
-		int64_t x = pt.x + C_Bias3D;
-		int64_t y = pt.y + C_Bias3D;
-		int64_t z = pt.z + C_Bias3D;
+		// Truncate each axis to its low C_Bits3D bits (the two's-complement representation of the value).
+		uint64_t x = static_cast<uint32_t>(pt.x) & C_Mask3D;
+		uint64_t y = static_cast<uint32_t>(pt.y) & C_Mask3D;
+		uint64_t z = static_cast<uint32_t>(pt.z) & C_Mask3D;
 
-		int64_t index = 0;
+		uint64_t index = 0;
 		for (int i = 0; i != C_Bits3D; ++i)
 		{
-			index |= (x & (1LL << i)) << (2 * i + 0); // safe: 2*i <= 40 < 64
-			index |= (y & (1LL << i)) << (2 * i + 1);
-			index |= (z & (1LL << i)) << (2 * i + 2);
+			index |= (x & (uint64_t{1} << i)) << (2 * i + 0); // safe: 2*i <= 40 < 64
+			index |= (y & (uint64_t{1} << i)) << (2 * i + 1);
+			index |= (z & (uint64_t{1} << i)) << (2 * i + 2);
 		}
-		return index;
+		return static_cast<int64_t>(index);
 	}
 
 
@@ -338,6 +346,23 @@ namespace pr::space_filling::tests
 				auto index = COrder3D(pt);
 				PR_EXPECT(index == i);
 			}
+
+			// Exact-value checks: index 0 maps to the origin, and small positive per-axis offsets
+			// map to the same small indices as the original (unbounded) implementation did for
+			// in-range inputs - confirming the low-bit two's-complement mapping is unchanged.
+			PR_EXPECT(COrder3D(iv4(0, 0, 0, 1)) == 0);
+			PR_EXPECT(COrder3D(iv4(1, 0, 0, 1)) == 1);
+			PR_EXPECT(COrder3D(iv4(0, 1, 0, 1)) == 3);
+			PR_EXPECT(COrder3D(iv4(0, 0, 1, 1)) == 7);
+			PR_EXPECT(All(COrder3D(int64_t(0)) == iv4(0, 0, 0, 1)));
+
+			// Explicit negative-coordinate round trips (in addition to the exhaustive sweep below).
+			for (auto pt : { iv4(-1, 0, 0, 1), iv4(0, -1, 0, 1), iv4(0, 0, -1, 1), iv4(-1, -1, -1, 1) })
+			{
+				auto index = COrder3D(pt);
+				auto pt2 = COrder3D(index);
+				PR_EXPECT(All(pt2 == pt));
+			}
 			for (int z = -20; z != 20; ++z)
 			{
 				for (int y = -20; y != 20; ++y)
@@ -374,6 +399,23 @@ namespace pr::space_filling::tests
 				auto index = ZOrder3D(pt);
 				PR_EXPECT(index == i);
 			}
+
+			// Exact-value checks: index 0 maps to the origin, and small positive per-axis offsets
+			// map to the same small indices as the original (unbounded) implementation did for
+			// in-range inputs - confirming the low-bit two's-complement mapping is unchanged.
+			PR_EXPECT(ZOrder3D(iv4(0, 0, 0, 1)) == 0);
+			PR_EXPECT(ZOrder3D(iv4(1, 0, 0, 1)) == 1);
+			PR_EXPECT(ZOrder3D(iv4(0, 1, 0, 1)) == 2);
+			PR_EXPECT(ZOrder3D(iv4(0, 0, 1, 1)) == 4);
+			PR_EXPECT(All(ZOrder3D(int64_t(0)) == iv4(0, 0, 0, 1)));
+
+			// Explicit negative-coordinate round trips (in addition to the exhaustive sweep below).
+			for (auto pt : { iv4(-1, 0, 0, 1), iv4(0, -1, 0, 1), iv4(0, 0, -1, 1), iv4(-1, -1, -1, 1) })
+			{
+				auto index = ZOrder3D(pt);
+				auto pt2 = ZOrder3D(index);
+				PR_EXPECT(All(pt2 == pt));
+			}
 			for (int z = -20; z != 20; ++z)
 			{
 				for (int y = -20; y != 20; ++y)
@@ -389,7 +431,7 @@ namespace pr::space_filling::tests
 			}
 
 			// Boundary values for the 3D curves: the minimum/maximum representable per-axis coordinate
-			// (C_Bias3D is the bias applied to each axis, see space_filling.h), plus values either side
+			// (C_Bias3D is the magnitude of the representable range either side of zero, see space_filling.h), plus values either side
 			// of zero. This exercises the extremes of the 21-bit-per-axis domain without triggering the
 			// out-of-range asserts, and confirms neither curve wraps or corrupts values near the boundary.
 			int const bounds3d[] = { -C_Bias3D, -C_Bias3D + 1, -1, 0, 1, C_Bias3D - 2, C_Bias3D - 1 };

--- a/include/pr/algorithm/space_filling.h
+++ b/include/pr/algorithm/space_filling.h
@@ -4,6 +4,7 @@
 //*************************************
 #pragma once
 #include <cstdint>
+#include <cassert>
 #include "pr/math/math.h"
 
 namespace pr::space_filling
@@ -57,36 +58,61 @@ namespace pr::space_filling
 		return index;
 	}
 
-	// Convert a ]-Order 3D index to a 3D point
+	// The 3D "]"-Order and Z-Order curves below interleave 3 bits per fractal level (one bit from
+	// each of x, y, z) into a single 64-bit index. Only floor(64/3) = 21 fractal levels fit before
+	// a per-level shift would reach or exceed the 64-bit width of the index, so each axis can only
+	// contribute 21 bits to the curve. Negative coordinates are supported by biasing each axis into
+	// the unsigned range [0, 2^C_Bits3D) before interleaving, and un-biasing again after extraction,
+	// rather than relying on signed integer overflow (which is undefined behaviour).
+	inline static constexpr int C_Bits3D = 8 * sizeof(int64_t) / 3; // 21 bits per axis (63 of the 64 index bits used)
+	inline static constexpr int32_t C_Bias3D = int32_t{1} << (C_Bits3D - 1); // 2^20, centres the representable range on the origin
+
+	// Convert a ]-Order 3D index to a 3D point.
+	// Only the low (3 * C_Bits3D) bits of 'index' are meaningful; higher bits are ignored. The
+	// reconstructed point's axes are each in the range [-C_Bias3D, C_Bias3D - 1].
 	inline iv4 COrder3D(int64_t index)
 	{
-		iv4 pt = {};
-		for (int i = 0; i != 32; ++i)
+		int64_t x = 0, y = 0, z = 0;
+		for (int i = 0; i != C_Bits3D; ++i)
 		{
 			auto oct = C_Order3DFwd[index & 0b111]; // oct we're in
-			pt.x += (1 << i) * ((oct >> 0) & 1); // += points/oct/axis at this level
-			pt.y += (1 << i) * ((oct >> 1) & 1);
-			pt.z += (1 << i) * ((oct >> 2) & 1);
+			x += (1LL << i) * ((oct >> 0) & 1); // += points/oct/axis at this level
+			y += (1LL << i) * ((oct >> 1) & 1);
+			z += (1LL << i) * ((oct >> 2) & 1);
 			index >>= 3;
 		}
-		return pt.w1();
+		return iv4(
+			static_cast<int32_t>(x - C_Bias3D),
+			static_cast<int32_t>(y - C_Bias3D),
+			static_cast<int32_t>(z - C_Bias3D),
+			1);
 	}
 
-	// Convert a 3D point to an index in the "]" Order 3D space filling curve
+	// Convert a 3D point to an index in the "]" Order 3D space filling curve.
+	// 'pt.x', 'pt.y', and 'pt.z' must each be in the range [-C_Bias3D, C_Bias3D - 1] (21 bits);
+	// coordinates outside that range cannot be represented by this curve.
 	inline int64_t COrder3D(iv4 pt)
 	{
+		assert(pt.x >= -C_Bias3D && pt.x < C_Bias3D && "COrder3D: x coordinate outside the representable 21-bit range");
+		assert(pt.y >= -C_Bias3D && pt.y < C_Bias3D && "COrder3D: y coordinate outside the representable 21-bit range");
+		assert(pt.z >= -C_Bias3D && pt.z < C_Bias3D && "COrder3D: z coordinate outside the representable 21-bit range");
+
+		int64_t x = pt.x + C_Bias3D;
+		int64_t y = pt.y + C_Bias3D;
+		int64_t z = pt.z + C_Bias3D;
+
 		int64_t index = 0;
-		for (int i = 0; i != 32; ++i)
+		for (int i = 0; i != C_Bits3D; ++i)
 		{
 			auto oct =
-				((pt.x & 1) << 0) |
-				((pt.y & 1) << 1) |
-				((pt.z & 1) << 2);
+				((x & 1) << 0) |
+				((y & 1) << 1) |
+				((z & 1) << 2);
 
-			index += C_Order3DInv[oct] * (1LL << (3 * i));
-			pt.x >>= 1;
-			pt.y >>= 1;
-			pt.z >>= 1;
+			index += C_Order3DInv[oct] * (1LL << (3 * i)); // safe: 3*i <= 3*(C_Bits3D - 1) = 60 < 64
+			x >>= 1;
+			y >>= 1;
+			z >>= 1;
 		}
 		return index;
 	}
@@ -120,28 +146,44 @@ namespace pr::space_filling
 		return index;
 	}
 
-	// Convert a Z-Order 3D index to a 3D point
+	// Convert a Z-Order 3D index to a 3D point.
+	// Only the low (3 * C_Bits3D) bits of 'index' are meaningful; higher bits are ignored. The
+	// reconstructed point's axes are each in the range [-C_Bias3D, C_Bias3D - 1].
 	inline iv4 ZOrder3D(int64_t index)
 	{
-		iv4 pt = { 0, 0, 0, 1 };
-		for (int i = 0; i < 32; ++i)
+		int64_t x = 0, y = 0, z = 0;
+		for (int i = 0; i != C_Bits3D; ++i)
 		{
-			pt.x |= (index & (1LL << (3 * i + 0))) >> (2 * i + 0);
-			pt.y |= (index & (1LL << (3 * i + 1))) >> (2 * i + 1);
-			pt.z |= (index & (1LL << (3 * i + 2))) >> (2 * i + 2);
+			x |= (index & (1LL << (3 * i + 0))) >> (2 * i + 0); // safe: 3*i <= 60, 2*i <= 40
+			y |= (index & (1LL << (3 * i + 1))) >> (2 * i + 1);
+			z |= (index & (1LL << (3 * i + 2))) >> (2 * i + 2);
 		}
-		return pt;
+		return iv4(
+			static_cast<int32_t>(x - C_Bias3D),
+			static_cast<int32_t>(y - C_Bias3D),
+			static_cast<int32_t>(z - C_Bias3D),
+			1);
 	}
 
-	// Convert a 3D point to an index in the Z-Order 3D space filling curve
+	// Convert a 3D point to an index in the Z-Order 3D space filling curve.
+	// 'pt.x', 'pt.y', and 'pt.z' must each be in the range [-C_Bias3D, C_Bias3D - 1] (21 bits);
+	// coordinates outside that range cannot be represented by this curve.
 	inline int64_t ZOrder3D(iv4 pt)
 	{
+		assert(pt.x >= -C_Bias3D && pt.x < C_Bias3D && "ZOrder3D: x coordinate outside the representable 21-bit range");
+		assert(pt.y >= -C_Bias3D && pt.y < C_Bias3D && "ZOrder3D: y coordinate outside the representable 21-bit range");
+		assert(pt.z >= -C_Bias3D && pt.z < C_Bias3D && "ZOrder3D: z coordinate outside the representable 21-bit range");
+
+		int64_t x = pt.x + C_Bias3D;
+		int64_t y = pt.y + C_Bias3D;
+		int64_t z = pt.z + C_Bias3D;
+
 		int64_t index = 0;
-		for (int i = 0; i != 32; ++i)
+		for (int i = 0; i != C_Bits3D; ++i)
 		{
-			index |= (pt.x & (1 << i)) << (2 * i + 0);
-			index |= (pt.y & (1 << i)) << (2 * i + 1);
-			index |= (pt.z & (1 << i)) << (2 * i + 2);
+			index |= (x & (1LL << i)) << (2 * i + 0); // safe: 2*i <= 40 < 64
+			index |= (y & (1LL << i)) << (2 * i + 1);
+			index |= (z & (1LL << i)) << (2 * i + 2);
 		}
 		return index;
 	}
@@ -296,6 +338,19 @@ namespace pr::space_filling::tests
 				auto index = COrder3D(pt);
 				PR_EXPECT(index == i);
 			}
+			for (int z = -20; z != 20; ++z)
+			{
+				for (int y = -20; y != 20; ++y)
+				{
+					for (int x = -20; x != 20; ++x)
+					{
+						auto pt = iv4(x, y, z, 1);
+						auto index = COrder3D(pt);
+						auto pt2 = COrder3D(index);
+						PR_EXPECT(All(pt2 == pt));
+					}
+				}
+			}
 			for (int y = -100; y != 100; ++y)
 			{
 				for (int x = -100; x != 100; ++x)
@@ -318,6 +373,43 @@ namespace pr::space_filling::tests
 				auto pt = ZOrder3D(i);
 				auto index = ZOrder3D(pt);
 				PR_EXPECT(index == i);
+			}
+			for (int z = -20; z != 20; ++z)
+			{
+				for (int y = -20; y != 20; ++y)
+				{
+					for (int x = -20; x != 20; ++x)
+					{
+						auto pt = iv4(x, y, z, 1);
+						auto index = ZOrder3D(pt);
+						auto pt2 = ZOrder3D(index);
+						PR_EXPECT(All(pt2 == pt));
+					}
+				}
+			}
+
+			// Boundary values for the 3D curves: the minimum/maximum representable per-axis coordinate
+			// (C_Bias3D is the bias applied to each axis, see space_filling.h), plus values either side
+			// of zero. This exercises the extremes of the 21-bit-per-axis domain without triggering the
+			// out-of-range asserts, and confirms neither curve wraps or corrupts values near the boundary.
+			int const bounds3d[] = { -C_Bias3D, -C_Bias3D + 1, -1, 0, 1, C_Bias3D - 2, C_Bias3D - 1 };
+			for (auto bz : bounds3d)
+			{
+				for (auto by : bounds3d)
+				{
+					for (auto bx : bounds3d)
+					{
+						auto pt = iv4(bx, by, bz, 1);
+
+						auto j_index = COrder3D(pt);
+						auto j_pt = COrder3D(j_index);
+						PR_EXPECT(All(j_pt == pt));
+
+						auto z_index = ZOrder3D(pt);
+						auto z_pt = ZOrder3D(z_index);
+						PR_EXPECT(All(z_pt == pt));
+					}
+				}
 			}
 
 			/* failing

--- a/include/pr/algorithm/space_filling.h
+++ b/include/pr/algorithm/space_filling.h
@@ -73,10 +73,14 @@ namespace pr::space_filling
 	inline static constexpr uint64_t C_Mask3D = (uint64_t{1} << C_Bits3D) - 1; // low C_Bits3D bits
 
 	// Sign-extend the low C_Bits3D bits of 'v' (all other bits must be zero) to a signed 32-bit value.
+	// 'v' is < 2^C_Bits3D, so the uint64_t -> int32_t conversion below always represents an in-range,
+	// non-negative value - it is not a narrowing/wrapping conversion. The subsequent subtraction is
+	// then plain int32_t arithmetic (no unsigned wraparound), keeping every step exactly representable.
 	inline constexpr int32_t SignExtend3D(uint64_t v)
 	{
 		constexpr uint64_t sign_bit = uint64_t{1} << (C_Bits3D - 1);
-		return static_cast<int32_t>((v ^ sign_bit) - sign_bit);
+		auto value = static_cast<int32_t>(v);
+		return (v & sign_bit) == 0 ? value : value - (int32_t{1} << C_Bits3D);
 	}
 
 	// Convert a ]-Order 3D index to a 3D point.
@@ -333,6 +337,14 @@ namespace pr::space_filling::tests
 		}
 		PRUnitTestMethod(JOrderTest)
 		{
+			// Sign-extension boundary checks: verify SignExtend3D decodes the raw 21-bit patterns
+			// at and either side of the sign boundary (bit C_Bits3D - 1) to the expected signed values.
+			PR_EXPECT(SignExtend3D(0) == 0);
+			PR_EXPECT(SignExtend3D(1) == 1);
+			PR_EXPECT(SignExtend3D(C_Mask3D) == -1); // all C_Bits3D bits set -> -1
+			PR_EXPECT(SignExtend3D(uint64_t{1} << (C_Bits3D - 1)) == -C_Bias3D); // sign bit only -> minimum representable value
+			PR_EXPECT(SignExtend3D((uint64_t{1} << (C_Bits3D - 1)) - 1) == C_Bias3D - 1); // sign bit clear, all lower bits set -> maximum representable value
+
 			// ]-Order
 			for (int i = -1000; i != 1000; ++i)
 			{


### PR DESCRIPTION
## Bug

`COrder3D` and `ZOrder3D` in `include/pr/algorithm/space_filling.h` pack 3 bits per fractal level into a 64-bit `int64_t` index, but their encode/decode loops iterated 32 levels — a bound copied from the 2D variants, which only pack 2 bits per level. This produces shift counts up to `3*31 = 93` (and `2*31+2 = 64`), all `>=` the 64-bit operand width, which is undefined behaviour per `[expr.shift]`. The shift executes unconditionally each iteration regardless of the multiplier/coordinate value, so even encoding the origin performs an invalid shift.

### Verified real, not just theoretical
Reproduced on MSVC x86-64 (Debug x64, VS 2026/v145): hardware `SHL` masks the shift count modulo 64/32, so the UB silently manifests as wraparound rather than a trap. Round-trip testing point → index → point for small coordinates near the origin showed:
- `ZOrder3D`: 19/27 round-trips failed for coordinates in `[-1,1]³`.
- `COrder3D`: 279/343 round-trips failed for coordinates in `[-3,3]³`.

The pre-existing unit tests didn't catch this because they only round-trip small non-negative *indices* (0–63 / 0–999), whose corrupted high-order shift terms happen to AND/OR with zero and cancel out — they never exercised point → index → point for real coordinates.

## Fix
- Only `floor(64/3) = 21` fractal levels fit in a 64-bit index at 3 bits/level, so both loops are now bounded to a new `C_Bits3D = 21` constant instead of the hardcoded `32`. Maximum shift becomes `3*20 = 60` (encode) / `2*20+2 = 42` (decode) — safely under 64.
- Each axis is treated as a 21-bit two's-complement value: **encoding masks the axis down to its low 21 bits** (`x & C_Mask3D` after a well-defined `int32_t`→`uint32_t` cast), and **decoding sign-extends bit 20 back out** via `SignExtend3D`. This reproduces the *exact* low-bit mapping the original code already produced for small-magnitude coordinates (index `0` ↔ origin, small positive offsets ↔ the same small indices), while remaining well-defined for the full 21-bit range instead of relying on signed-overflow UB.
- `SignExtend3D` converts the bounded (`< 2^21`) unsigned value directly to `int32_t` (an exact, non-narrowing conversion) and then does the sign-extension as plain signed `int32_t` arithmetic (`value - (1 << 21)` when the sign bit is set) — no unsigned subtraction/wraparound followed by an out-of-range narrowing conversion, so every step is fully well-defined, not just legal-under-C++20-modulo-semantics.
  - Two earlier iterations of this fix were caught in review: a bias-add scheme that changed the index↔point mapping (index 0 no longer decoded to the origin), and a `(v ^ sign_bit) - sign_bit` sign-extension that relied on unsigned wraparound before an implementation-defined-looking narrowing conversion. Both are replaced by the explicit truncate/sign-extend approach described above.
- All bit manipulation is done in `uint64_t` throughout the interleaving loops; the signed `int64_t`/`int32_t` API types are only used at the function boundary (casts happen once on entry/exit, and `SignExtend3D`'s cast is always exact).
- Documented the representable per-axis domain (`[-C_Bias3D, C_Bias3D - 1]`, i.e. 21 bits) directly on each function, with debug-mode `assert`s guarding the encode direction.
- `2D` `COrder2D`/`ZOrder2D` and `Hilbert2D` were checked and are unaffected (max shift ≤ 63) — left untouched.

## Testing
- `SignExtend3D` boundary checks: `0`, `1`, all-bits-set (`-1`), sign-bit-only (minimum value), sign-bit-clear-with-all-lower-bits-set (maximum value) — plus an exhaustive standalone check of all `2^21` possible inputs against the expected two's-complement value (0 failures).
- Exact-value checks: `COrder3D(origin) == 0`, `ZOrder3D(origin) == 0`, `COrder3D(0) == origin`, `ZOrder3D(0) == origin`, and small positive per-axis offsets map to the same small indices (`1`, `2`/`3`, `4`/`7`) as before.
- Explicit negative-coordinate round trips, plus point → index → point round-trip tests over `[-20,20)³` for both `COrder3D` and `ZOrder3D`.
- Explicit boundary-value tests (min/max representable coordinate per axis, and values either side of zero) for both orderings.
- Existing tests (index round-trip for small values, 2D exhaustive round-trip) continue to pass unchanged.
- A standalone repro mirroring the header logic verified 1,000,000 round-trip checks (±50 range including negatives) plus all exact/boundary checks with zero failures before rebuilding the full solution.
- Built `unittests.vcxproj` in Debug x64 (VS 2026, v145 toolset) and ran the full suite: **all 988 unit tests passed**.
- Also built `physics.vcxproj` (Debug x64), which contains `include/pr/physics/utility/field.h`, the caller of these APIs — compiles cleanly with the new signatures (no changes needed there).

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
Copilot-Session: d9a205d4-a5bf-4f2b-9f98-43b40da90cdd