### PR TITLE
Fix UTF-16 max code point

### DIFF
--- a/include/pr/str/convert_utf.h
+++ b/include/pr/str/convert_utf.h
@@ -251,7 +251,7 @@ namespace pr::str
 					obuf[0] = static_cast<ou_char_t>(m_ibuf & 0xFFFFu);
 					out(&obuf[0], &obuf[0] + 1);
 				}
-				else if (m_ibuf < 0x10FFFFu)
+				else if (m_ibuf <= 0x10FFFFu && (m_ibuf < 0xD800u || m_ibuf > 0xDFFFu))
 				{
 					m_ibuf -= 0x010000u;
 					obuf[0] = static_cast<ou_char_t>(((m_ibuf >> 10) & 0x03FFu) + 0xD800u);

--- a/include/pr/str/unit_tests.h
+++ b/include/pr/str/unit_tests.h
@@ -106,6 +106,37 @@ namespace pr::str
 				PR_EXPECT(UTEqual(r.c_str(), {0x007a, 0x00df, 0x6c34, 0xd83c, 0xdf4c, 0}));
 			}
 		}
+		PRUnitTestMethod(ConvertUtf)
+		{
+			using namespace unittests;
+
+			// Supplementary-plane scalars must encode to UTF-16 surrogate pairs, while
+			// invalid scalars stay unrepresentable and fall back to the replacement code.
+			{
+				char32_t const cp[] = { 0x10FFFE, 0 };
+				auto r = convert_utf<char32_t, char16_t>::convert<std::u16string>(std::u32string_view(cp, 1));
+				PR_EXPECT(r.size() == 2U);
+				PR_EXPECT(UTEqual(r.c_str(), { 0xDBFF, 0xDFFE, 0 }));
+			}
+			{
+				char32_t const cp[] = { 0x10FFFF, 0 };
+				auto r = convert_utf<char32_t, char16_t>::convert<std::u16string>(std::u32string_view(cp, 1));
+				PR_EXPECT(r.size() == 2U);
+				PR_EXPECT(UTEqual(r.c_str(), { 0xDBFF, 0xDFFF, 0 }));
+			}
+			{
+				char32_t const cp[] = { 0x110000, 0 };
+				auto r = convert_utf<char32_t, char16_t>::convert<std::u16string>(std::u32string_view(cp, 1));
+				PR_EXPECT(r.size() == 1U);
+				PR_EXPECT(UTEqual(r.c_str(), { 0x005F, 0 }));
+			}
+			{
+				char32_t const cp[] = { 0xD800, 0 };
+				auto r = convert_utf<char32_t, char16_t>::convert<std::u16string>(std::u32string_view(cp, 1));
+				PR_EXPECT(r.size() == 1U);
+				PR_EXPECT(UTEqual(r.c_str(), { 0x005F, 0 }));
+			}
+		}
 		PRUnitTestMethod(Empty)
 		{
 			char const* aptr = "full";
@@ -626,5 +657,4 @@ namespace pr::str
 	};
 }
 #endif
-
 


### PR DESCRIPTION
Fixes the UTF-16 branch in convert_utf so U+10FFFF encodes as the final surrogate pair and surrogate code points fall back to the replacement character.

Verification:
- Focused standalone VS2026/v145 Debug x64 harness reproduced the bug before the fix and passed after the fix.
- The pr::str unit tests compile and run cleanly in that harness.