### PR TITLE
Fix byte-data alignment

### DIFF
--- a/include/pr/common/expr_eval.h
+++ b/include/pr/common/expr_eval.h
@@ -639,21 +639,9 @@ namespace pr::eval
 	static_assert(std::is_trivially_copyable_v<Val>, "Val must be pod for performance");
 	static_assert(std::alignment_of_v<Val> == 32, "Val should have 32 byte alignment");
 
-	// Expression bytecode stores typed payloads in a byte buffer, so the evaluator copies
-	// values in and out with memcpy instead of forming typed references at arbitrary offsets.
-	template <typename Type> Type ReadValue(byte_data<> const& data, size_t& ofs)
-	{
-		if (ofs + sizeof(Type) > data.size())
-			throw std::out_of_range("read attempt beyond buffer end");
-
-		Type value;
-		std::memcpy(&value, data.data() + ofs, sizeof(Type));
-		ofs += sizeof(Type);
-		return value;
-	}
 	template <typename Type> void WriteValue(byte_data<>& data, size_t ofs, Type const& value)
 	{
-		if (ofs + sizeof(Type) > data.size())
+		if (ofs > data.size() || sizeof(Type) > data.size() - ofs)
 			throw std::out_of_range("write attempt beyond buffer end");
 
 		std::memcpy(data.data() + ofs, &value, sizeof(Type));
@@ -972,7 +960,7 @@ namespace pr::eval
 			Stack stack;
 			for (size_t i = 0, iend = m_op.size(); i != iend;)
 			{
-				auto tok = ReadValue<ETok>(m_op, i);
+				auto tok = m_op.read<ETok>(i);
 				switch (tok)
 				{
 					case ETok::None:
@@ -981,29 +969,29 @@ namespace pr::eval
 					}
 					case ETok::Identifier:
 					{
-						auto hash = ReadValue<IdentHash>(m_op, i);
+						auto hash = m_op.read<IdentHash>(i);
 						stack.push_back(args(hash));
 						break;
 					}
 					case ETok::Value:
 					{
 						// Deserialise a 'Val' instance
-						auto ty = ReadValue<Val::EType>(m_op, i);
+						auto ty = m_op.read<Val::EType>(i);
 						switch (ty)
 						{
-							case Val::EType::Intg: stack.push_back(ReadValue<long long>(m_op, i)); break;
-							case Val::EType::Real: stack.push_back(ReadValue<double>(m_op, i)); break;
+							case Val::EType::Intg: stack.push_back(m_op.read<long long>(i)); break;
+							case Val::EType::Real: stack.push_back(m_op.read<double>(i)); break;
 							case Val::EType::Intg4:
 							{
-								auto v = ReadValue<Val::IVec4>(m_op, i);
-								auto dim = ReadValue<uint8_t>(m_op, i);
+								auto v = m_op.read<Val::IVec4>(i);
+								auto dim = m_op.read<uint8_t>(i);
 								stack.push_back(Val(v, dim));
 								break;
 							}
 							case Val::EType::Real4:
 							{
-								auto v = ReadValue<Val::Vec4>(m_op, i);
-								auto dim = ReadValue<uint8_t>(m_op, i);
+								auto v = m_op.read<Val::Vec4>(i);
+								auto dim = m_op.read<uint8_t>(i);
 								stack.push_back(Val(v, dim));
 								break;
 							}
@@ -1015,7 +1003,7 @@ namespace pr::eval
 					{
 						// Construct a vec4 from N (1..4) scalar values popped from the stack.
 						// Missing components default to 0. Vector-valued elements are not allowed.
-						auto n = ReadValue<uint8_t>(m_op, i);
+						auto n = m_op.read<uint8_t>(i);
 						if (n < 1 || n > 4) throw std::runtime_error("Invalid vector literal element count");
 						if (stack.size() < n) throw std::runtime_error("Insufficient arguments for vector literal");
 
@@ -1610,15 +1598,15 @@ namespace pr::eval
 					{
 						if (stack.size() < 1) throw std::runtime_error("Insufficient arguments for if expression");
 						auto boolean = stack.back(); stack.pop_back();
-						auto jmp = ReadValue<int>(m_op, i);
+						auto jmp = m_op.read<int>(i);
 						if (boolean == Val(0))
 						{
 							i += jmp;
 
 							// If the next instruction is an 'else' statement, skip over it so that the else body
 							// gets executed. Remember If == branch-if-zero, Else == branch-always
-							ETok next_tok;
-							std::memcpy(&next_tok, m_op.data() + i, sizeof(next_tok));
+							auto next_i = i;
+							auto next_tok = m_op.read<ETok>(next_i);
 							if (next_tok == ETok::Else)
 								i += sizeof(ETok) + sizeof(int);
 						}
@@ -1626,7 +1614,7 @@ namespace pr::eval
 					}
 					case ETok::Else:
 					{
-						auto jmp = ReadValue<int>(m_op, i);
+						auto jmp = m_op.read<int>(i);
 						i += jmp;
 						break;
 					}

--- a/include/pr/common/expr_eval.h
+++ b/include/pr/common/expr_eval.h
@@ -8,9 +8,11 @@
 #include <limits>
 #include <string_view>
 #include <algorithm>
+#include <cstring>
 #include <type_traits>
 #include <initializer_list>
 #include <cassert>
+#include <stdexcept>
 #include "pr/common/fmt.h"
 #include "pr/common/hash.h"
 #include "pr/math/math.h"
@@ -637,6 +639,26 @@ namespace pr::eval
 	static_assert(std::is_trivially_copyable_v<Val>, "Val must be pod for performance");
 	static_assert(std::alignment_of_v<Val> == 32, "Val should have 32 byte alignment");
 
+	// Expression bytecode stores typed payloads in a byte buffer, so the evaluator copies
+	// values in and out with memcpy instead of forming typed references at arbitrary offsets.
+	template <typename Type> Type ReadValue(byte_data<> const& data, size_t& ofs)
+	{
+		if (ofs + sizeof(Type) > data.size())
+			throw std::out_of_range("read attempt beyond buffer end");
+
+		Type value;
+		std::memcpy(&value, data.data() + ofs, sizeof(Type));
+		ofs += sizeof(Type);
+		return value;
+	}
+	template <typename Type> void WriteValue(byte_data<>& data, size_t ofs, Type const& value)
+	{
+		if (ofs + sizeof(Type) > data.size())
+			throw std::out_of_range("write attempt beyond buffer end");
+
+		std::memcpy(data.data() + ofs, &value, sizeof(Type));
+	}
+
 	// A collection of args with some rules enforced
 	struct ArgSet
 	{
@@ -950,7 +972,7 @@ namespace pr::eval
 			Stack stack;
 			for (size_t i = 0, iend = m_op.size(); i != iend;)
 			{
-				auto tok = m_op.read<ETok>(i);
+				auto tok = ReadValue<ETok>(m_op, i);
 				switch (tok)
 				{
 					case ETok::None:
@@ -959,29 +981,29 @@ namespace pr::eval
 					}
 					case ETok::Identifier:
 					{
-						auto hash = m_op.read<IdentHash>(i);
+						auto hash = ReadValue<IdentHash>(m_op, i);
 						stack.push_back(args(hash));
 						break;
 					}
 					case ETok::Value:
 					{
 						// Deserialise a 'Val' instance
-						auto ty = m_op.read<Val::EType>(i);
+						auto ty = ReadValue<Val::EType>(m_op, i);
 						switch (ty)
 						{
-							case Val::EType::Intg: stack.push_back(m_op.read<long long>(i)); break;
-							case Val::EType::Real: stack.push_back(m_op.read<double>(i)); break;
+							case Val::EType::Intg: stack.push_back(ReadValue<long long>(m_op, i)); break;
+							case Val::EType::Real: stack.push_back(ReadValue<double>(m_op, i)); break;
 							case Val::EType::Intg4:
 							{
-								auto v = m_op.read<Val::IVec4>(i);
-								auto dim = m_op.read<uint8_t>(i);
+								auto v = ReadValue<Val::IVec4>(m_op, i);
+								auto dim = ReadValue<uint8_t>(m_op, i);
 								stack.push_back(Val(v, dim));
 								break;
 							}
 							case Val::EType::Real4:
 							{
-								auto v = m_op.read<Val::Vec4>(i);
-								auto dim = m_op.read<uint8_t>(i);
+								auto v = ReadValue<Val::Vec4>(m_op, i);
+								auto dim = ReadValue<uint8_t>(m_op, i);
 								stack.push_back(Val(v, dim));
 								break;
 							}
@@ -993,7 +1015,7 @@ namespace pr::eval
 					{
 						// Construct a vec4 from N (1..4) scalar values popped from the stack.
 						// Missing components default to 0. Vector-valued elements are not allowed.
-						auto n = m_op.read<uint8_t>(i);
+						auto n = ReadValue<uint8_t>(m_op, i);
 						if (n < 1 || n > 4) throw std::runtime_error("Invalid vector literal element count");
 						if (stack.size() < n) throw std::runtime_error("Insufficient arguments for vector literal");
 
@@ -1588,21 +1610,23 @@ namespace pr::eval
 					{
 						if (stack.size() < 1) throw std::runtime_error("Insufficient arguments for if expression");
 						auto boolean = stack.back(); stack.pop_back();
-						auto jmp = m_op.read<int>(i);
+						auto jmp = ReadValue<int>(m_op, i);
 						if (boolean == Val(0))
 						{
 							i += jmp;
 
 							// If the next instruction is an 'else' statement, skip over it so that the else body
 							// gets executed. Remember If == branch-if-zero, Else == branch-always
-							if (m_op.at_byte_ofs<ETok>(i) == ETok::Else)
+							ETok next_tok;
+							std::memcpy(&next_tok, m_op.data() + i, sizeof(next_tok));
+							if (next_tok == ETok::Else)
 								i += sizeof(ETok) + sizeof(int);
 						}
 						break;
 					}
 					case ETok::Else:
 					{
-						auto jmp = m_op.read<int>(i);
+						auto jmp = ReadValue<int>(m_op, i);
 						i += jmp;
 						break;
 					}
@@ -2321,7 +2345,7 @@ namespace pr::eval
 
 					// Determine the offset to jump over the if body. The jump is from the byte after the jump value.
 					auto jmp = static_cast<int>(compiled.m_op.size() - ofs0 - sizeof(int));
-					compiled.m_op.at_byte_ofs<int>(ofs0) = jmp;
+					WriteValue(compiled.m_op, ofs0, jmp);
 					break;
 				}
 				case ETok::Else:
@@ -2341,7 +2365,7 @@ namespace pr::eval
 
 					// Determine the offset to jump over the else body
 					auto jmp = static_cast<int>(compiled.m_op.size() - ofs0 - sizeof(int));
-					compiled.m_op.at_byte_ofs<int>(ofs0) = jmp;
+					WriteValue(compiled.m_op, ofs0, jmp);
 					return true;
 				}
 				default:

--- a/include/pr/container/byte_data.h
+++ b/include/pr/container/byte_data.h
@@ -3,6 +3,8 @@
 //  Copyright (c) Oct 2003 Paul Ryland
 //******************************************
 #pragma once
+#include <array>
+#include <bit>
 #include <cstdint>
 #include <cstring>
 #include <vector>
@@ -489,13 +491,13 @@ namespace pr
 		template <typename Type> Type read(size_t& ofs) const
 		{
 			static_assert(std::is_trivially_copyable_v<Type>);
-			if (ofs + sizeof(Type) > size())
+			if (ofs > size() || sizeof(Type) > size() - ofs)
 				throw std::out_of_range("read attempt beyond buffer end");
 
-			Type value{};
-			std::memcpy(&value, m_ptr + ofs, sizeof(Type));
+			std::array<std::byte, sizeof(Type)> bytes{};
+			std::memcpy(bytes.data(), m_ptr + ofs, sizeof(Type));
 			ofs += sizeof(Type);
-			return value;
+			return std::bit_cast<Type>(bytes);
 		}
 
 		// implicit conversions
@@ -636,18 +638,18 @@ namespace pr
 			return *reinterpret_cast<Type const*>(m_beg);
 		}
 		
-		// Advance the pointer by the size of 'Type'
+		// Read one value and advance by 'count' elements of 'Type'.
 		template <typename Type> Type read(int count = 1)
 		{
 			static_assert(std::is_trivially_copyable_v<Type>);
 			auto size = m_beg == nullptr ? size_t(0) : static_cast<size_t>(m_end - m_beg);
-			if (count < 0 || size < static_cast<size_t>(count) * sizeof(Type))
+			if (count < 0 || static_cast<size_t>(count) > size / sizeof(Type))
 				throw std::out_of_range("buffer overrun");
 
-			Type value{};
-			std::memcpy(&value, m_beg, sizeof(Type));
-			m_beg += sizeof(Type);
-			return value;
+			std::array<std::byte, sizeof(Type)> bytes{};
+			std::memcpy(bytes.data(), m_beg, sizeof(Type));
+			m_beg += static_cast<ptrdiff_t>(count) * static_cast<ptrdiff_t>(sizeof(Type));
+			return std::bit_cast<Type>(bytes);
 		}
 
 		// Read bytes to align to 'alignment'
@@ -694,17 +696,18 @@ namespace pr
 			return *reinterpret_cast<Type*>(m_beg);
 		}
 		
-		// Advance the pointer by the size of 'Type'
+		// Write one value and advance by 'count' elements of 'Type'.
 		template <typename Type> void write(Type const& value, int count = 1)
 		{
 			static_assert(std::is_trivially_copyable_v<Type>);
 			auto size = m_beg == nullptr ? size_t(0) : static_cast<size_t>(m_end - m_beg);
-			if (count < 0 || size < static_cast<size_t>(count) * sizeof(Type))
+			if (count < 0 || static_cast<size_t>(count) > size / sizeof(Type))
 				throw std::out_of_range("buffer overrun");
 
+			auto bytes = std::bit_cast<std::array<std::byte, sizeof(Type)>>(value);
 			for (; count-- != 0;)
 			{
-				std::memcpy(m_beg, &value, sizeof(Type));
+				std::memcpy(m_beg, bytes.data(), sizeof(Type));
 				m_beg += sizeof(Type);
 			}
 		}
@@ -965,6 +968,30 @@ namespace pr::container
 			auto const v2 = cbuf0.template at_byte_ofs<int>(0);
 			PR_EXPECT(v2 == 0);
 
+			// Non-default-constructible trivially-copyable values should still round-trip.
+			struct NonDefaultTrivial
+			{
+				std::uint32_t m_value;
+				NonDefaultTrivial() = delete;
+			};
+			static_assert(std::is_trivially_copyable_v<NonDefaultTrivial>);
+			static_assert(!std::is_default_constructible_v<NonDefaultTrivial>);
+
+			auto const raw = std::array<std::byte, sizeof(NonDefaultTrivial)>{
+				std::byte{ 0x78 }, std::byte{ 0x56 }, std::byte{ 0x34 }, std::byte{ 0x12 }
+			};
+			auto const nd_value = std::bit_cast<NonDefaultTrivial>(raw);
+
+			byte_data buf_nd;
+			buf_nd.push_back(nd_value);
+			size_t nd_ofs = 0;
+			auto nd_read = buf_nd.read<NonDefaultTrivial>(nd_ofs);
+			PR_EXPECT(nd_read.m_value == 0x12345678U);
+
+			byte_data_cptr cptr_nd(buf_nd.span());
+			auto nd_peek = cptr_nd.read<NonDefaultTrivial>();
+			PR_EXPECT(nd_peek.m_value == 0x12345678U);
+
 			auto s = buf0.span<int>();
 			PR_EXPECT(s.size() == 4U);
 			PR_EXPECT(s[0] == 0);
@@ -988,55 +1015,25 @@ namespace pr::container
 			PR_EXPECT(cbuf2.data_at<OverAligned>(0)->m_value == 0x8877665544332211ULL);
 
 			// Check the two failure modes independently so the test documents both the size and alignment contracts.
-			bool threw = false;
-			try
-			{
-				(void)buf2.at_byte_ofs<OverAligned>(1);
-			}
-			catch (...)
-			{
-				threw = true;
-			}
-			PR_EXPECT(threw);
+			PR_THROWS(buf2.at_byte_ofs<OverAligned>(1), std::out_of_range);
 
 			byte_data<64> buf3;
 			buf3.resize(sizeof(OverAligned) + 1);
-			threw = false;
-			try
-			{
-				(void)buf3.at_byte_ofs<OverAligned>(1);
-			}
-			catch (...)
-			{
-				threw = true;
-			}
-			PR_EXPECT(threw);
+			PR_THROWS(buf3.at_byte_ofs<OverAligned>(1), std::runtime_error);
 
 			std::span<std::byte const> misaligned_const{ buf2.data() + 1, sizeof(OverAligned) };
 			byte_data_cptr cptr(misaligned_const);
-			threw = false;
-			try
-			{
-				(void)cptr.as<OverAligned>();
-			}
-			catch (...)
-			{
-				threw = true;
-			}
-			PR_EXPECT(threw);
+			PR_THROWS((cptr.as<OverAligned>()), std::runtime_error);
 
 			std::span<std::byte> misaligned_mut{ buf2.data() + 1, sizeof(OverAligned) };
 			byte_data_mptr mptr(misaligned_mut);
-			threw = false;
-			try
-			{
-				(void)mptr.as<OverAligned>();
-			}
-			catch (...)
-			{
-				threw = true;
-			}
-			PR_EXPECT(threw);
+			PR_THROWS((mptr.as<OverAligned>()), std::runtime_error);
+
+			// Align-to must skip the full padding width, not just one byte.
+			std::array<std::byte, 4> pad_bytes{ std::byte{0}, std::byte{1}, std::byte{2}, std::byte{3} };
+			byte_data_cptr align_ptr(std::span<std::byte const>{ pad_bytes.data() + 1, pad_bytes.size() - 1 });
+			align_ptr.align_to(4);
+			PR_EXPECT(align_ptr.m_beg == pad_bytes.data() + 4);
 		}
 		{ // Stream
 			byte_data buf0;

--- a/include/pr/container/byte_data.h
+++ b/include/pr/container/byte_data.h
@@ -4,11 +4,13 @@
 //******************************************
 #pragma once
 #include <cstdint>
+#include <cstring>
 #include <vector>
 #include <span>
 #include <concepts>
 #include <initializer_list>
 #include <sstream>
+#include <stdexcept>
 #include <malloc.h>
 #include <intrin.h>
 
@@ -376,7 +378,7 @@ namespace pr
 		// Return the buffer interpreted as 'Type'
 		template <typename Type> Type const& as() const
 		{
-			return *begin<Type>();
+			return *checked_ptr<Type>(0);
 		}
 		value_type const& as() const
 		{
@@ -384,7 +386,7 @@ namespace pr
 		}
 		template <typename Type> Type& as()
 		{
-			return *begin<Type>();
+			return *checked_ptr<Type>(0);
 		}
 		value_type& as()
 		{
@@ -394,7 +396,10 @@ namespace pr
 		// Indexed addressing in the buffer interpreted as an array of 'Type'
 		template <typename Type> Type const& at(size_t index) const
 		{
-			return begin<Type>()[index];
+			if (index >= size<Type>())
+				throw std::out_of_range("Index out of range");
+
+			return *checked_ptr<Type>(index * sizeof(Type));
 		}
 		value_type const& at(size_t index) const
 		{
@@ -402,21 +407,25 @@ namespace pr
 		}
 		template <typename Type> Type& at(size_t index)
 		{
-			return begin<Type>()[index];
+			if (index >= size<Type>())
+				throw std::out_of_range("Index out of range");
+
+			return *checked_ptr<Type>(index * sizeof(Type));
 		}
 		value_type& at(size_t index)
 		{
 			return begin()[index];
 		}
 
-		// Return a reference to 'Type' at a byte offset into the container
+		// Return a reference to 'Type' at a byte offset into the container.
+		// The offset must land on an address that satisfies alignof(Type).
 		template <typename Type> Type const& at_byte_ofs(size_t byte_ofs) const
 		{
-			return *reinterpret_cast<Type const*>(m_ptr + byte_ofs);
+			return *checked_ptr<Type>(byte_ofs);
 		}
 		template <typename Type> Type& at_byte_ofs(size_t byte_ofs)
 		{
-			return *reinterpret_cast<Type*>(m_ptr + byte_ofs);
+			return *checked_ptr<Type>(byte_ofs);
 		}
 
 		// Array access to bytes
@@ -447,14 +456,15 @@ namespace pr
 			return begin();
 		}
 
-		// A pointer to the data starting at the given byte offset
+		// A typed pointer to the data starting at the given byte offset.
+		// This applies the same bounds and alignment checks as 'at_byte_ofs'.
 		template <typename Type> Type const* data_at(size_t byte_ofs) const
 		{
-			return &at_byte_ofs<Type>(byte_ofs);
+			return checked_ptr<Type>(byte_ofs);
 		}
 		template <typename Type> Type* data_at(size_t byte_ofs)
 		{
-			return &at_byte_ofs<Type>(byte_ofs);
+			return checked_ptr<Type>(byte_ofs);
 		}
 
 		// Façade access
@@ -476,14 +486,16 @@ namespace pr
 		}
 
 		// Streaming access
-		template <typename Type> Type const& read(size_t& ofs) const
+		template <typename Type> Type read(size_t& ofs) const
 		{
+			static_assert(std::is_trivially_copyable_v<Type>);
 			if (ofs + sizeof(Type) > size())
 				throw std::out_of_range("read attempt beyond buffer end");
 
-			auto& r = at_byte_ofs<Type>(ofs);
+			Type value{};
+			std::memcpy(&value, m_ptr + ofs, sizeof(Type));
 			ofs += sizeof(Type);
-			return r;
+			return value;
 		}
 
 		// implicit conversions
@@ -497,6 +509,24 @@ namespace pr
 		}
 
 	private:
+
+		// Resolve a typed access after validating the byte range and the target type's alignment.
+		// Byte-oriented callers should stay on the raw byte APIs when they do not need typed access.
+		template <typename Type> Type const* checked_ptr(size_t byte_ofs) const
+		{
+			if (byte_ofs > m_size || sizeof(Type) > m_size - byte_ofs)
+				throw std::out_of_range("Offset position out of range");
+
+			auto ptr = m_ptr + byte_ofs;
+			if ((reinterpret_cast<std::uintptr_t>(ptr) % alignof(Type)) != 0)
+				throw std::runtime_error("Type access is misaligned");
+
+			return reinterpret_cast<Type const*>(ptr);
+		}
+		template <typename Type> Type* checked_ptr(size_t byte_ofs)
+		{
+			return const_cast<Type*>(static_cast<byte_data const&>(*this).template checked_ptr<Type>(byte_ofs));
+		}
 
 		// Convert a void pointer to a byte pointer
 		static value_type const* byte_ptr(void const* ptr)
@@ -596,21 +626,28 @@ namespace pr
 		// Interpret the current 'm_beg' pointer as 'Type'
 		template <typename Type> Type const& as() const
 		{
-			if (m_beg + sizeof(Type) > m_end)
+			auto size = m_beg == nullptr ? size_t(0) : static_cast<size_t>(m_end - m_beg);
+			if (sizeof(Type) > size)
 				throw std::out_of_range("buffer overrun");
+
+			if ((reinterpret_cast<std::uintptr_t>(m_beg) % alignof(Type)) != 0)
+				throw std::runtime_error("Type access is misaligned");
 
 			return *reinterpret_cast<Type const*>(m_beg);
 		}
 		
 		// Advance the pointer by the size of 'Type'
-		template <typename Type> Type const& read(int count = 1)
+		template <typename Type> Type read(int count = 1)
 		{
-			if (m_beg + count * sizeof(Type) > m_end)
+			static_assert(std::is_trivially_copyable_v<Type>);
+			auto size = m_beg == nullptr ? size_t(0) : static_cast<size_t>(m_end - m_beg);
+			if (count < 0 || size < static_cast<size_t>(count) * sizeof(Type))
 				throw std::out_of_range("buffer overrun");
 
-			auto& r = as<Type>();
-			m_beg += count * sizeof(Type);
-			return r;
+			Type value{};
+			std::memcpy(&value, m_beg, sizeof(Type));
+			m_beg += sizeof(Type);
+			return value;
 		}
 
 		// Read bytes to align to 'alignment'
@@ -647,18 +684,27 @@ namespace pr
 		// Interpret the current 'm_beg' pointer as 'Type'
 		template <typename Type> Type& as() const
 		{
+			auto size = m_beg == nullptr ? size_t(0) : static_cast<size_t>(m_end - m_beg);
+			if (sizeof(Type) > size)
+				throw std::out_of_range("buffer overrun");
+
+			if ((reinterpret_cast<std::uintptr_t>(m_beg) % alignof(Type)) != 0)
+				throw std::runtime_error("Type access is misaligned");
+
 			return *reinterpret_cast<Type*>(m_beg);
 		}
 		
 		// Advance the pointer by the size of 'Type'
 		template <typename Type> void write(Type const& value, int count = 1)
 		{
-			if (m_beg + count * sizeof(Type) >m_end)
+			static_assert(std::is_trivially_copyable_v<Type>);
+			auto size = m_beg == nullptr ? size_t(0) : static_cast<size_t>(m_end - m_beg);
+			if (count < 0 || size < static_cast<size_t>(count) * sizeof(Type))
 				throw std::out_of_range("buffer overrun");
 
 			for (; count-- != 0;)
 			{
-				as<Type>() = value;
+				std::memcpy(m_beg, &value, sizeof(Type));
 				m_beg += sizeof(Type);
 			}
 		}
@@ -894,6 +940,11 @@ namespace pr::container
 			for (int i = 0; i != 4; ++i) { PR_EXPECT(buf1[i + 6] == buf0[i]); }
 		}
 		{ // Access
+			struct alignas(64) OverAligned
+			{
+				std::uint64_t m_value;
+			};
+
 			byte_data buf0;
 			buf0.append({0, 1, 2, 3});
 			PR_EXPECT(buf0.size<int>() == 4U);
@@ -906,8 +957,13 @@ namespace pr::container
 			PR_EXPECT(arr0[3] == 3);
 
 			// at_byte_ofs
-			auto v1 = buf0.at_byte_ofs<int>(2);
-			PR_EXPECT(v1 == 0x00010000);
+			auto v1 = buf0.at_byte_ofs<int>(0);
+			PR_EXPECT(v1 == 0);
+
+			// const typed access
+			auto const& cbuf0 = buf0;
+			auto const v2 = cbuf0.template at_byte_ofs<int>(0);
+			PR_EXPECT(v2 == 0);
 
 			auto s = buf0.span<int>();
 			PR_EXPECT(s.size() == 4U);
@@ -915,6 +971,72 @@ namespace pr::container
 			PR_EXPECT(s[1] == 1);
 			PR_EXPECT(s[2] == 2);
 			PR_EXPECT(s[3] == 3);
+
+			// over-aligned access
+			byte_data<64> buf2;
+			buf2.push_back(OverAligned{ 0x1122334455667788ULL });
+			PR_EXPECT((reinterpret_cast<std::uintptr_t>(buf2.data()) % alignof(OverAligned)) == 0);
+			PR_EXPECT(buf2.at_byte_ofs<OverAligned>(0).m_value == 0x1122334455667788ULL);
+			PR_EXPECT(buf2.data_at<OverAligned>(0)->m_value == 0x1122334455667788ULL);
+
+			auto& aligned_ref = buf2.at_byte_ofs<OverAligned>(0);
+			aligned_ref.m_value = 0x8877665544332211ULL;
+			PR_EXPECT(buf2.at_byte_ofs<OverAligned>(0).m_value == 0x8877665544332211ULL);
+
+			auto const& cbuf2 = buf2;
+			PR_EXPECT(cbuf2.at_byte_ofs<OverAligned>(0).m_value == 0x8877665544332211ULL);
+			PR_EXPECT(cbuf2.data_at<OverAligned>(0)->m_value == 0x8877665544332211ULL);
+
+			// Check the two failure modes independently so the test documents both the size and alignment contracts.
+			bool threw = false;
+			try
+			{
+				(void)buf2.at_byte_ofs<OverAligned>(1);
+			}
+			catch (...)
+			{
+				threw = true;
+			}
+			PR_EXPECT(threw);
+
+			byte_data<64> buf3;
+			buf3.resize(sizeof(OverAligned) + 1);
+			threw = false;
+			try
+			{
+				(void)buf3.at_byte_ofs<OverAligned>(1);
+			}
+			catch (...)
+			{
+				threw = true;
+			}
+			PR_EXPECT(threw);
+
+			std::span<std::byte const> misaligned_const{ buf2.data() + 1, sizeof(OverAligned) };
+			byte_data_cptr cptr(misaligned_const);
+			threw = false;
+			try
+			{
+				(void)cptr.as<OverAligned>();
+			}
+			catch (...)
+			{
+				threw = true;
+			}
+			PR_EXPECT(threw);
+
+			std::span<std::byte> misaligned_mut{ buf2.data() + 1, sizeof(OverAligned) };
+			byte_data_mptr mptr(misaligned_mut);
+			threw = false;
+			try
+			{
+				(void)mptr.as<OverAligned>();
+			}
+			catch (...)
+			{
+				threw = true;
+			}
+			PR_EXPECT(threw);
 		}
 		{ // Stream
 			byte_data buf0;

--- a/include/pr/view3d-12/forward.h
+++ b/include/pr/view3d-12/forward.h
@@ -31,6 +31,7 @@
 #include <chrono>
 #include <limits>
 #include <span>
+#include <cstring>
 #include <tuple>
 #include <source_location>
 #include <type_traits>

--- a/projects/rylogic/view3d-12/src/ldraw/sources/source_stream.cpp
+++ b/projects/rylogic/view3d-12/src/ldraw/sources/source_stream.cpp
@@ -2,6 +2,7 @@
 // View 3d
 //  Copyright (c) Rylogic Ltd 2022
 //*********************************************
+#include <cstring>
 #include "view3d-12/src/ldraw/sources/source_stream.h"
 #include "pr/view3d-12/ldraw/ldraw_object.h"
 #include "pr/view3d-12/ldraw/ldraw_reader_text.h"
@@ -149,7 +150,8 @@ namespace pr::rdr12::ldraw
 		// Find the range of complete sections that can be consumed
 		for (; bytes_read - consume >= int(sizeof(ldraw::SectionHeader));)
 		{
-			auto const& header = buffer.at_byte_ofs<ldraw::SectionHeader>(s_cast<size_t>(consume));
+			ldraw::SectionHeader header;
+			std::memcpy(&header, buffer.data() + consume, sizeof(header));
 
 			// If the first 4 bytes are not a keyword, then flush the buffer
 			if (!ldraw::EKeyword_::IsValue(s_cast<int>(header.m_keyword)))
@@ -195,7 +197,8 @@ namespace pr::rdr12::ldraw
 		// Otherwise, if 0 bytes can be consumed, check the buffer is big enough and the partial data is not invalid
 		else if (bytes_read >= sizeof(ldraw::SectionHeader))
 		{
-			auto const& header = buffer.at_byte_ofs<ldraw::SectionHeader>(s_cast<size_t>(0));
+			ldraw::SectionHeader header;
+			std::memcpy(&header, buffer.data(), sizeof(header));
 			required = header.m_size + sizeof(ldraw::SectionHeader);
 		}
 
@@ -282,7 +285,8 @@ namespace pr::rdr12::ldraw
 		// If we have enough bytes for a section header, check for a valid keyword
 		if (bytes_read >= static_cast<int>(sizeof(ldraw::SectionHeader)))
 		{
-			auto const& header = buffer.at_byte_ofs<ldraw::SectionHeader>(0);
+			ldraw::SectionHeader header;
+			std::memcpy(&header, buffer.data(), sizeof(header));
 			if (ldraw::EKeyword_::IsValue(s_cast<int>(header.m_keyword)))
 				return EMode::Binary;
 		}

--- a/projects/rylogic/view3d-12/src/ldraw/sources/source_stream.cpp
+++ b/projects/rylogic/view3d-12/src/ldraw/sources/source_stream.cpp
@@ -2,7 +2,6 @@
 // View 3d
 //  Copyright (c) Rylogic Ltd 2022
 //*********************************************
-#include <cstring>
 #include "view3d-12/src/ldraw/sources/source_stream.h"
 #include "pr/view3d-12/ldraw/ldraw_object.h"
 #include "pr/view3d-12/ldraw/ldraw_reader_text.h"


### PR DESCRIPTION
Harden byte-oriented value reads in byte_data so streamed data is copied by value instead of forming typed references, which keeps non-default-constructible trivially-copyable types supported. Preserve cursor advancement for multi-element reads, keep expr_eval on the generic byte_data read API, and leave alignment-checked pointer/span-style accessors as separate contract surfaces.

Also remove the direct <cstring> include from source_stream.cpp and route it through the View3D forward header.

Validation:
- projects/tests/unittests/unittests.vcxproj (Debug x64)
- projects/rylogic/view3d-12/view3d-12.vcxproj (Debug x64)
- projects/tests/physics-sandbox/physics-sandbox.vcxproj (Debug x64)