### PR TITLE
Fix Step semantics

### DIFF
--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -1989,10 +1989,10 @@ namespace pr::math
 		return len_sq > 0 ? Sqrt(len_sq) : 0;
 	}
 
-	// Returns 1 if 'hi' is > 'lo' otherwise 0
+	// Returns 0 when 'hi' is below 'lo'; otherwise 1
 	template <ScalarType S> constexpr S Step(S lo, S hi) noexcept
 	{
-		return lo <= hi ? S(0) : S(1);
+		return hi < lo ? S(0) : S(1);
 	}
 
 	// Returns the 'Hermite' interpolation (3t^2 - 2t^3) between 'lo' and 'hi' for t=[0,1]

--- a/include/pr/math/tests/function_tests.h
+++ b/include/pr/math/tests/function_tests.h
@@ -2151,9 +2151,10 @@ namespace pr::math::tests
 		) {
 			using S = T;
 
-			PR_EXPECT(Step(S(0), S(1)) == S(0)); // lo <= hi → 0
-			PR_EXPECT(Step(S(1), S(0)) == S(1)); // lo > hi → 1
-			PR_EXPECT(Step(S(5), S(5)) == S(0)); // lo == hi → 0
+			// Step returns 0 below the edge, and 1 at or above it.
+			PR_EXPECT(Step(S(1), S(0)) == S(0)); // hi < lo → 0
+			PR_EXPECT(Step(S(1), S(1)) == S(1)); // hi == lo → 1
+			PR_EXPECT(Step(S(1), S(2)) == S(1)); // hi > lo → 1
 		}
 
 		// ---- Sigmoid (functions.h line ~1653) ----


### PR DESCRIPTION
## Summary
- align `pr::math::Step` with its documented and standard step semantics: return `0` below the edge and `1` at or above it
- update the focused native unit tests to cover less-than, equal, and greater-than cases for `float`, `double`, `int32_t`, and `int64_t`

## Evidence
- `Step` previously returned the opposite result for less/greater comparisons and also returned `0` on equality
- `Step`, `SmoothStep`, and the matching native tests were all introduced together, and the reversed tests arrived in the same change as the inverted implementation
- a repo-wide caller scan found no native `pr::math::Step` callers outside the function's own unit tests, so the old behaviour was not depended on in-tree
- the managed analogue in `Rylogic.Core` still has the same inverted implementation, which supports this being a copied defect rather than an intentional native-only contract

## Validation
- built `projects/tests/unittests/unittests.vcxproj` with VS2026 MSBuild in `Debug|x64`
- native unit tests passed: `All 1010 unit tests passed.`