### PR TITLE
Fix scalar CompOp overloads

### DIFF
--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -851,18 +851,22 @@ namespace pr::math
 		return true;
 	}
 
-	// Compile time function for applying 'op' to each component of a vector
+	// Compile time function for applying 'op' to a scalar or each component of a vector
 	template <ScalarType S, typename Op> constexpr S CompOp(S a, Op op)
 	{
+		return op(a);
 	}
 	template <ScalarType S, typename Op> constexpr S CompOp(S a, S b, Op op)
 	{
+		return op(a, b);
 	}
 	template <ScalarType S, typename Op> constexpr S CompOp(S a, S b, S c, Op op)
 	{
+		return op(a, b, c);
 	}
 	template <ScalarType S, typename Op> constexpr S CompOp(S a, S b, S c, S d, Op op)
 	{
+		return op(a, b, c, d);
 	}
 	template <VectorType Vec, typename Op> constexpr Vec CompOp(Vec a, Op op)
 	{

--- a/include/pr/math/tests/function_tests.h
+++ b/include/pr/math/tests/function_tests.h
@@ -338,6 +338,19 @@ namespace pr::math::tests
 			}
 		}
 
+		// ---- CompOp (functions.h line ~855) ----
+		PRUnitTestMethod(CompOpTests
+		, float, double, int32_t, int64_t
+		) {
+			using S = T;
+
+			// Scalar overloads should forward their arguments to the supplied operation and return that result unchanged.
+			static_assert(CompOp(S(2), [](S x) { return x + S(1); }) == S(3));
+			static_assert(CompOp(S(2), S(5), [](S x, S y) { return x * S(10) + y; }) == S(25));
+			static_assert(CompOp(S(2), S(5), S(7), [](S x, S y, S z) { return x + y + z; }) == S(14));
+			static_assert(CompOp(S(2), S(5), S(7), S(11), [](S x, S y, S z, S w) { return x + y + z + w; }) == S(25));
+		}
+
 		// ---- Abs (functions.h line ~675) ----
 		PRUnitTestMethod(Abs
 		, Vec2<float>, Vec2<double>, Vec2<int32_t>, Vec2<int64_t>


### PR DESCRIPTION
## Summary
- implement the scalar `CompOp` overloads for arities 1 through 4 by invoking and returning the supplied operation
- keep the vector overload family unchanged while aligning the shared scalar/vector semantics
- add focused native unit coverage for scalar `CompOp` across representative scalar types with constexpr assertions

## Validation
- compile a minimal repro translation unit containing `constexpr auto value = pr::math::CompOp(2, [](int x) { return x + 1; });`
- build the VS2026/v145 Debug x64 native dependency chain ending at `projects\tests\unittests\unittests.vcxproj`
- run `projects\tests\unittests\obj\x64\Debug\unittests.exe`
