### PR TITLE
Clarify Quantise truncation contract

### DIFF
--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -1935,10 +1935,10 @@ namespace pr::math
 		return len * vec;
 	}
 
-	// Quantise a value to a power of two. 'scale' should be a power of 2, i.e. 256, 1024, 2048, etc
+	// Quantise a value by truncating it onto a 1/'scale' grid. 'scale' should be a power of 2, i.e. 256, 1024, 2048, etc
 	template <ScalarTypeFP S, std::integral I> constexpr S Quantise(S x, I scale) noexcept
 	{
-		// The purpose of 'Quantise' is to round 'x' to the nearest representable floating number using 'N' mantissa bits where '1 << N' == 'scale.
+		// This intentionally truncates toward zero after scaling. Use Round/Trunc(..., ETruncate::ToNearest) when callers need nearest rounding.
 		return static_cast<I>(x * scale) / static_cast<S>(scale);
 	}
 	template <VectorTypeFP Vec, std::integral I> constexpr Vec pr_vectorcall Quantise(Vec v, I scale) noexcept

--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -1935,10 +1935,10 @@ namespace pr::math
 		return len * vec;
 	}
 
-	// Quantise a value by truncating it onto a 1/'scale' grid. 'scale' should be a power of 2, i.e. 256, 1024, 2048, etc
+	// Quantise a value by truncating toward zero onto a 1/'scale' grid.
 	template <ScalarTypeFP S, std::integral I> constexpr S Quantise(S x, I scale) noexcept
 	{
-		// This intentionally truncates toward zero after scaling. Use Round/Trunc(..., ETruncate::ToNearest) when callers need nearest rounding.
+		// This intentionally truncates toward zero after scaling. Use Round(x * scale) / scale when nearest-grid rounding is required.
 		return static_cast<I>(x * scale) / static_cast<S>(scale);
 	}
 	template <VectorTypeFP Vec, std::integral I> constexpr Vec pr_vectorcall Quantise(Vec v, I scale) noexcept

--- a/include/pr/math/tests/function_tests.h
+++ b/include/pr/math/tests/function_tests.h
@@ -2116,12 +2116,20 @@ namespace pr::math::tests
 
 			// Scalar quantise
 			PR_EXPECT(Quantise(S(0.123456), 100) == S(0.12));
+			PR_EXPECT(Quantise(S(0.76), 2) == S(0.5));
+			PR_EXPECT(Quantise(S(-0.76), 2) == S(-0.5));
+			PR_EXPECT(Quantise(S(0.75), 2) == S(0.5));
+			PR_EXPECT(Quantise(S(-0.75), 2) == S(-0.5));
 			PR_EXPECT(Quantise(S(0.999), 10) == S(0.9));
 
 			// Vector quantise
 			auto v = vec_t(S(0.123456));
 			auto q = Quantise(v, 100);
 			PR_EXPECT(FEql(q, vec_t(S(0.12))));
+
+			auto boundary = vec_t(S(-0.75));
+			auto boundary_q = Quantise(boundary, 2);
+			PR_EXPECT(FEql(boundary_q, vec_t(S(-0.5))));
 		}
 
 		// ---- SmoothStep (functions.h line ~1637) ----


### PR DESCRIPTION
## Summary
- clarify that `pr::math::Quantise(scale)` intentionally truncates toward zero instead of rounding to nearest
- keep the existing implementation unchanged
- add scalar/vector boundary tests that lock the long-standing truncation behaviour

## Evidence
- direct repro on current code returns `Quantise(0.76f, 2) == 0.5`, `Quantise(0.999f, 10) == 0.9`, and `Quantise(-0.76f, 2) == -0.5`
- legacy `include/pr/maths/maths_core.h` and historical vector tests already encoded truncation semantics
- C# keeps separate APIs for truncation (`Quantise(x, scale)`) and nearest rounding (`Quantise(x, quantum)`)
- the terrain exporter carries its own round-to-nearest helper instead of using `pr::math::Quantise`

## Validation
- VS2026/v145 Debug x64: `projects/tests/unittests/unittests.vcxproj` -> all 1010 unit tests passed
- VS2026/v145 Debug x64: `projects/tools/p3d/p3d.vcxproj` build succeeded