### PR TITLE
Fix ISqrt overflow on large integral inputs

### DIFF
--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -1132,42 +1132,50 @@ namespace pr::math
 	// Integer square root
 	template <std::integral T> constexpr T ISqrt(T x) noexcept
 	{
-		// Returns the nearest integer root without ever forming an intermediate square larger than the input.
-		if constexpr (std::signed_integral<T>)
+		// Bool is already its own nearest integer square root and does not participate in the unsigned-root machinery below.
+		if constexpr (std::same_as<T, bool>)
 		{
-			if (x < 0)
-				return std::numeric_limits<T>::quiet_NaN();
+			return x;
 		}
-
-		using U = std::make_unsigned_t<T>;
-		auto const ux = static_cast<U>(x);
-		if (ux < 2)
-			return static_cast<T>(ux);
-
-		// Find the largest root whose square does not exceed the input using only division-based comparisons.
-		auto lo = U(1);
-		auto hi = ux / 2 + 1;
-		auto root = U(1);
-		for (; lo <= hi; )
+		else
 		{
-			U const mid = static_cast<U>(lo + ((hi - lo) >> 1));
-			if (mid <= ux / mid)
+			// Returns the nearest integer root without ever forming an intermediate square larger than the input.
+			if constexpr (std::signed_integral<T>)
 			{
-				root = mid;
-				lo = static_cast<U>(mid + U(1));
+				if (x < 0)
+					return std::numeric_limits<T>::quiet_NaN();
 			}
-			else
-			{
-				hi = static_cast<U>(mid - U(1));
-			}
-		}
 
-		// The lower square is always representable because it is bounded by the input. The remainder above that square
-		// decides whether the lower or upper root is closer, and there is no tie because adjacent squares differ by an odd amount.
-		auto const square = root * root;
-		auto const remainder = ux - square;
-		auto const nearest = remainder > root ? root + 1 : root;
-		return static_cast<T>(nearest);
+			using U = std::make_unsigned_t<T>;
+			auto const ux = static_cast<U>(x);
+			if (ux < 2)
+				return static_cast<T>(ux);
+
+			// Find the largest root whose square does not exceed the input using only division-based comparisons.
+			auto lo = U(1);
+			auto hi = ux / 2 + 1;
+			auto root = U(1);
+			for (; lo <= hi; )
+			{
+				U const mid = static_cast<U>(lo + ((hi - lo) >> 1));
+				if (mid <= ux / mid)
+				{
+					root = mid;
+					lo = static_cast<U>(mid + U(1));
+				}
+				else
+				{
+					hi = static_cast<U>(mid - U(1));
+				}
+			}
+
+			// The lower square is always representable because it is bounded by the input. The remainder above that square
+			// decides whether the lower or upper root is closer, and there is no tie because adjacent squares differ by an odd amount.
+			auto const square = root * root;
+			auto const remainder = ux - square;
+			auto const nearest = remainder > root ? root + 1 : root;
+			return static_cast<T>(nearest);
+		}
 	}
 	template <std::integral T> constexpr T CompISqrt(T x) noexcept
 	{

--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -1132,21 +1132,42 @@ namespace pr::math
 	// Integer square root
 	template <std::integral T> constexpr T ISqrt(T x) noexcept
 	{
-		// Compile time version of the square root.
-		//  - For a finite and non-negative value of "x", returns an approximation for the square root of "x"
-		//  - This method always converges or oscillates about the answer with a difference of 1.
-		//  - Otherwise, returns 0
-		if (x < 0)
-			return std::numeric_limits<T>::quiet_NaN();
-
-		T curr = x, prev = 0, pprev = 0;
-		for (;curr != prev && curr != pprev;)
+		// Returns the nearest integer root without ever forming an intermediate square larger than the input.
+		if constexpr (std::signed_integral<T>)
 		{
-			pprev = prev;
-			prev = curr;
-			curr = (curr + x / curr) >> 1;
+			if (x < 0)
+				return std::numeric_limits<T>::quiet_NaN();
 		}
-		return Abs(x - curr * curr) < Abs(x - prev * prev) ? curr : prev;
+
+		using U = std::make_unsigned_t<T>;
+		auto const ux = static_cast<U>(x);
+		if (ux < 2)
+			return static_cast<T>(ux);
+
+		// Find the largest root whose square does not exceed the input using only division-based comparisons.
+		auto lo = U(1);
+		auto hi = ux / 2 + 1;
+		auto root = U(1);
+		for (; lo <= hi; )
+		{
+			U const mid = static_cast<U>(lo + ((hi - lo) >> 1));
+			if (mid <= ux / mid)
+			{
+				root = mid;
+				lo = static_cast<U>(mid + U(1));
+			}
+			else
+			{
+				hi = static_cast<U>(mid - U(1));
+			}
+		}
+
+		// The lower square is always representable because it is bounded by the input. The remainder above that square
+		// decides whether the lower or upper root is closer, and there is no tie because adjacent squares differ by an odd amount.
+		auto const square = root * root;
+		auto const remainder = ux - square;
+		auto const nearest = remainder > root ? root + 1 : root;
+		return static_cast<T>(nearest);
 	}
 	template <std::integral T> constexpr T CompISqrt(T x) noexcept
 	{

--- a/include/pr/math/tests/function_tests.h
+++ b/include/pr/math/tests/function_tests.h
@@ -25,6 +25,94 @@ namespace pr::math::tests
 				return All(lhs == rhs);
 		};
 
+		// Returns the expected nearest integer square root of the largest representable value for each tested scalar width.
+		template <std::integral S> static constexpr S ExpectedMaxISqrt()
+		{
+			if constexpr (std::signed_integral<S>)
+			{
+				if constexpr (sizeof(S) == 1)
+				{
+					return S(11);
+				}
+				if constexpr (sizeof(S) == 2)
+				{
+					return S(181);
+				}
+				if constexpr (sizeof(S) == 4)
+				{
+					return S(46341);
+				}
+				if constexpr (sizeof(S) == 8)
+				{
+					return S(3037000500LL);
+				}
+			}
+			else
+			{
+				if constexpr (sizeof(S) == 1)
+				{
+					return S(16);
+				}
+				if constexpr (sizeof(S) == 2)
+				{
+					return S(256);
+				}
+				if constexpr (sizeof(S) == 4)
+				{
+					return S(65536);
+				}
+				if constexpr (sizeof(S) == 8)
+				{
+					return S(4294967296ULL);
+				}
+			}
+
+			static_assert(sizeof(S) == 1 || sizeof(S) == 2 || sizeof(S) == 4 || sizeof(S) == 8);
+			return S();
+		}
+
+		// Checks the scalar nearest-root contract around exact squares, rounding thresholds, signed sentinels, and type limits.
+		template <std::integral S> static constexpr void CheckScalarISqrt()
+		{
+			using U = std::make_unsigned_t<S>;
+
+			static_assert(ISqrt(S(0)) == S(0));
+			static_assert(ISqrt(S(1)) == S(1));
+			static_assert(ISqrt(S(2)) == S(1));
+			static_assert(ISqrt(S(3)) == S(2));
+			static_assert(ISqrt(S(4)) == S(2));
+			static_assert(ISqrt(S(6)) == S(2));
+			static_assert(ISqrt(S(7)) == S(3));
+			static_assert(ISqrt(S(9)) == S(3));
+			static_assert(ISqrt(S(10)) == S(3));
+			static_assert(ISqrt(S(12)) == S(3));
+			static_assert(ISqrt(S(13)) == S(4));
+			static_assert(ISqrt(S(99)) == S(10));
+			static_assert(ISqrt(S(100)) == S(10));
+			static_assert(ISqrt(S(110)) == S(10));
+			static_assert(ISqrt(S(111)) == S(11));
+			static_assert(ISqrt(std::numeric_limits<S>::max()) == ExpectedMaxISqrt<S>());
+			static_assert(ISqrt(std::numeric_limits<S>::max() - S(1)) == ExpectedMaxISqrt<S>());
+
+			if constexpr (std::signed_integral<S>)
+			{
+				static_assert(ISqrt(S(-1)) == S(0));
+				static_assert(ISqrt(S(-9)) == S(0));
+			}
+			else
+			{
+				constexpr auto floor_root = U((U(1) << (std::numeric_limits<U>::digits / 2)) - 1);
+				constexpr auto ceil_root = U(floor_root + 1);
+				constexpr auto square = U(floor_root * floor_root);
+				constexpr auto threshold = U(square + floor_root);
+
+				static_assert(ISqrt(S(square - 1)) == S(floor_root));
+				static_assert(ISqrt(S(square + 0)) == S(floor_root));
+				static_assert(ISqrt(S(threshold + 0)) == S(floor_root));
+				static_assert(ISqrt(S(threshold + 1)) == S(ceil_root));
+			}
+		}
+
 		PRUnitTestMethod(ExplicitCasts
 		, Vec2<float>, Vec2<double>, Vec2<int32_t>, Vec2<int64_t>
 		, Vec3<float>, Vec3<double>, Vec3<int32_t>, Vec3<int64_t>
@@ -451,9 +539,18 @@ namespace pr::math::tests
 			}
 		}
 
-		// ---- ISqrt (functions.h line ~830) ----
-		PRUnitTestMethod(ISqrtAndCompISqrtTests
-		, int32_t, int64_t
+		// ---- ISqrt (functions.h line ~1133) ----
+		PRUnitTestMethod(ISqrtScalarTests
+		, int8_t, uint8_t
+		, int16_t, uint16_t
+		, int32_t, uint32_t
+		, int64_t, uint64_t
+		) {
+			CheckScalarISqrt<T>();
+		}
+
+		// ---- CompISqrt (functions.h line ~1160) ----
+		PRUnitTestMethod(CompISqrtTests
 		, Vec2<int32_t>, Vec2<int64_t>
 		, Vec3<int32_t>, Vec3<int64_t>
 		, Vec4<int32_t>, Vec4<int64_t>
@@ -463,24 +560,13 @@ namespace pr::math::tests
 		) {
 			using S = T;
 
-			if constexpr (VectorType<T>)
-			{
-				static_assert(All(CompISqrt(S(0)) == S(0)));
-				static_assert(All(CompISqrt(S(1)) == S(1)));
-				static_assert(All(CompISqrt(S(4)) == S(2)));
-				static_assert(All(CompISqrt(S(9)) == S(3)));
-				static_assert(All(CompISqrt(S(10)) == S(3)));
-				static_assert(All(CompISqrt(S(100)) == S(10)));
-			}
-			else
-			{
-				static_assert(ISqrt(S(0)) == S(0));
-				static_assert(ISqrt(S(1)) == S(1));
-				static_assert(ISqrt(S(4)) == S(2));
-				static_assert(ISqrt(S(9)) == S(3));
-				static_assert(ISqrt(S(10)) == S(3));
-				static_assert(ISqrt(S(100)) == S(10));
-			}
+			static_assert(All(CompISqrt(S(0)) == S(0)));
+			static_assert(All(CompISqrt(S(1)) == S(1)));
+			static_assert(All(CompISqrt(S(4)) == S(2)));
+			static_assert(All(CompISqrt(S(9)) == S(3)));
+			static_assert(All(CompISqrt(S(10)) == S(3)));
+			static_assert(All(CompISqrt(S(99)) == S(10)));
+			static_assert(All(CompISqrt(S(100)) == S(10)));
 		}
 
 		// ---- CompSum (functions.h line ~850) ----

--- a/include/pr/math/tests/function_tests.h
+++ b/include/pr/math/tests/function_tests.h
@@ -540,6 +540,16 @@ namespace pr::math::tests
 		}
 
 		// ---- ISqrt (functions.h line ~1133) ----
+		PRUnitTestMethod(ISqrtBoolTests
+		, bool
+		) {
+			static_assert(ISqrt(false) == false);
+			static_assert(ISqrt(true) == true);
+			static_assert(CompISqrt(false) == false);
+			static_assert(CompISqrt(true) == true);
+		}
+
+		// ---- ISqrt scalar values (functions.h line ~1133) ----
 		PRUnitTestMethod(ISqrtScalarTests
 		, int8_t, uint8_t
 		, int16_t, uint16_t

--- a/include/pr/math/tests/function_tests.h
+++ b/include/pr/math/tests/function_tests.h
@@ -543,6 +543,10 @@ namespace pr::math::tests
 		PRUnitTestMethod(ISqrtBoolTests
 		, bool
 		) {
+			static_assert(std::is_same_v<decltype(ISqrt(false)), bool>);
+			static_assert(std::is_same_v<decltype(ISqrt(true)), bool>);
+			static_assert(std::is_same_v<decltype(CompISqrt(false)), bool>);
+			static_assert(std::is_same_v<decltype(CompISqrt(true)), bool>);
 			static_assert(ISqrt(false) == false);
 			static_assert(ISqrt(true) == true);
 			static_assert(CompISqrt(false) == false);


### PR DESCRIPTION
## Summary
- replace `pr::math::ISqrt`''s overflow-prone Newton iteration with a division-based floor-root search plus remainder-based nearest rounding
- preserve the existing negative-input behaviour for signed integrals while handling all tested signed and unsigned widths in constexpr evaluation
- add strong constexpr boundary coverage for perfect squares, halfway decisions, signed maxima, `UINT64_MAX`, and values near the largest representable unsigned root

## Reproduction
- before this change, a standalone native repro returned `18446744073709551615` for `ISqrt(std::numeric_limits<uint64_t>::max())` instead of the nearest integer root `4294967296`

## Validation
- `C:\Program Files\Microsoft Visual Studio\18\Enterprise\MSBuild\Current\Bin\amd64\MSBuild.exe` `projects\tests\unittests\unittests.vcxproj` `/p:Configuration=Debug` `/p:Platform=x64` `/nologo` `/verbosity:minimal`
- post-build unit test run: `All 1011 unit tests passed.`
