### PR TITLE
Fix Mat6x8 transpose tags

### DIFF
--- a/include/pr/math/tests/matrix6x8_tests.h
+++ b/include/pr/math/tests/matrix6x8_tests.h
@@ -51,22 +51,30 @@ namespace pr::math::tests
 
 		PRUnitTestMethod(Transpose, float, double)
 		{
+			struct SpaceA {};
+			struct SpaceB {};
+			using mat3_t = Mat3x3<T>;
 			using mat6_t = Mat6x8<T, void, void>;
-			using vec8_t = Vec8<T, void>;
+			using tagged_mat_t = Mat6x8<T, SpaceA, SpaceB>;
+
+			// The transpose of an A->B mapping must be typed as a B->A mapping.
+			static_assert(std::is_same_v<decltype(Transpose(tagged_mat_t{})), Mat6x8<T, SpaceB, SpaceA>>);
 
 			auto M = mat6_t
 			{
-				vec8_t{1, 0, 0, 0, 0, 0},
-				vec8_t{0, 2, 0, 0, 0, 0},
-				vec8_t{0, 0, 3, 0, 0, 0},
-				vec8_t{0, 0, 0, 4, 0, 0},
-				vec8_t{0, 0, 0, 0, 5, 0},
-				vec8_t{0, 0, 0, 0, 0, 6},
+				mat3_t{Vec3<T>{T( 1), T( 2), T( 3)}, Vec3<T>{T( 4), T( 5), T( 6)}, Vec3<T>{T( 7), T( 8), T( 9)}},
+				mat3_t{Vec3<T>{T(10), T(11), T(12)}, Vec3<T>{T(13), T(14), T(15)}, Vec3<T>{T(16), T(17), T(18)}},
+				mat3_t{Vec3<T>{T(19), T(20), T(21)}, Vec3<T>{T(22), T(23), T(24)}, Vec3<T>{T(25), T(26), T(27)}},
+				mat3_t{Vec3<T>{T(28), T(29), T(30)}, Vec3<T>{T(31), T(32), T(33)}, Vec3<T>{T(34), T(35), T(36)}},
 			};
 			auto Mt = Transpose(M);
 
-			// Diagonal matrix transpose is itself
-			PR_EXPECT(FEql(M, Mt));
+			// Check that the transpose swaps the off-diagonal blocks without changing their element layout.
+			PR_EXPECT(FEql(Mt.m00, Transpose(M.m00)));
+			PR_EXPECT(FEql(Mt.m01, Transpose(M.m10)));
+			PR_EXPECT(FEql(Mt.m10, Transpose(M.m01)));
+			PR_EXPECT(FEql(Mt.m11, Transpose(M.m11)));
+			PR_EXPECT(FEql(Transpose(Mt), M));
 		}
 
 		PRUnitTestMethod(Inverse, float, double)

--- a/include/pr/math/types/matrix6x8.h
+++ b/include/pr/math/types/matrix6x8.h
@@ -183,10 +183,11 @@ namespace pr::math
 				FEql(lhs.m11, rhs.m11);
 		}
 
-		// Return the transpose of a spatial matrix
-		friend constexpr Mat6x8 Transpose(Mat6x8 const& mat) noexcept
+		// Return the transpose of a spatial matrix.
+		// The transpose reverses the source/destination spaces while preserving the existing block layout.
+		friend constexpr Mat6x8<S, B, A> Transpose(Mat6x8 const& mat) noexcept
 		{
-			return Mat6x8(
+			return Mat6x8<S, B, A>(
 				Transpose(mat.m00), Transpose(mat.m10),
 				Transpose(mat.m01), Transpose(mat.m11)
 			);
@@ -288,11 +289,12 @@ namespace pr::math
 			IsNaN(m.m11, any);
 	}
 
-	// Return the transpose of a spatial matrix
+	// Return the transpose of a spatial matrix.
+	// The transpose reverses the source/destination spaces while preserving the existing block layout.
 	template <ScalarType S, typename A, typename B>
-	constexpr Mat6x8<S, A, B> pr_vectorcall Transpose(Mat6x8<S,A,B> const& m)
+	constexpr Mat6x8<S, B, A> pr_vectorcall Transpose(Mat6x8<S, A, B> const& m)
 	{
-		return Mat6x8<S, A, B>(
+		return Mat6x8<S, B, A>(
 			Transpose(m.m00), Transpose(m.m10),
 			Transpose(m.m01), Transpose(m.m11));
 	}


### PR DESCRIPTION
## Summary
- return `Mat6x8<S, B, A>` from both `Transpose(Mat6x8<...>)` overloads so the spatial source/destination tags swap correctly
- preserve the existing 2x2 block transpose layout and lock it down with focused tests
- add a compile-time tag assertion plus a numerical block-transpose round-trip check

## Validation
- compiled a proof snippet against `main` showing `decltype(Transpose(Mat6x8<float, SpaceA, SpaceB>{}))` was `Mat6x8<float, SpaceA, SpaceB>`
- compiled the same proof against this branch showing the type is now `Mat6x8<float, SpaceB, SpaceA>`
- built `sdk\lua\lua.vcxproj`, `projects\rylogic\physics\physics.vcxproj`, and `projects\rylogic\view3d-12\view3d-12.vcxproj` in VS2026/v145 Debug x64 as dependencies
- built and ran `projects\tests\unittests\unittests.vcxproj` in VS2026/v145 Debug x64 (`1010` unit tests passed)