### PR TITLE
Fix constexpr half conversion

### DIFF
--- a/include/pr/math/tests/half_tests.h
+++ b/include/pr/math/tests/half_tests.h
@@ -48,18 +48,40 @@ namespace pr::math::tests
 
 		PRUnitTestMethod(CompileTimeConversion)
 		{
-			// constexpr round-trip
-			constexpr auto h1 = F32toF16CT(1.0f);
-			constexpr auto f1 = F16toF32CT(h1);
+			// Constexpr uses the public API so the test fails if constant evaluation ever falls back to the runtime-only path again.
+			constexpr auto h1 = F32toF16(1.0f);
+			constexpr auto f1 = F16toF32(h1);
 			static_assert(f1 == 1.0f);
 
-			constexpr auto h0 = F32toF16CT(0.0f);
-			constexpr auto f0 = F16toF32CT(h0);
+			constexpr auto h0 = F32toF16(0.0f);
+			constexpr auto f0 = F16toF32(h0);
 			static_assert(f0 == 0.0f);
 
-			constexpr auto hm = F32toF16CT(-0.5f);
-			constexpr auto fm = F16toF32CT(hm);
+			constexpr auto hm = F32toF16(-0.5f);
+			constexpr auto fm = F16toF32(hm);
 			static_assert(fm == -0.5f);
+
+			static_assert(F32toF16(-0.0f) == half_t{0x8000u});
+			static_assert(F32toF16(0x1.0p-24f) == half_t{0x0001u});
+			static_assert(F32toF16(0x1.0p-14f) == half_t{0x0400u});
+			static_assert(F32toF16(65504.0f) == half_t{0x7bffu});
+			static_assert(F32toF16(std::bit_cast<float>(0x7fc00000u)) == half_t{0x7e00u});
+			static_assert(std::bit_cast<uint32_t>(F16toF32(half_t{0x0001u})) == 0x33800000u);
+			static_assert(std::bit_cast<uint32_t>(F16toF32(half_t{0x03ffu})) == 0x387fc000u);
+			static_assert(std::bit_cast<uint32_t>(F16toF32(half_t{0x7e00u})) == 0x7fc00000u);
+
+			// This reproduces the original regression: constexpr vector conversion must stay on the constexpr scalar path.
+			constexpr auto hv = F32toF16(Vec4<float>{1.0f, -0.5f, 0.25f, -0.0f});
+			static_assert(hv.x == half_t{0x3c00u});
+			static_assert(hv.y == half_t{0xb800u});
+			static_assert(hv.z == half_t{0x3400u});
+			static_assert(hv.w == half_t{0x8000u});
+
+			constexpr auto fv = F16toF32<Vec4<float>>(hv);
+			static_assert(fv.x == 1.0f);
+			static_assert(fv.y == -0.5f);
+			static_assert(fv.z == 0.25f);
+			static_assert(std::bit_cast<uint32_t>(fv.w) == 0x80000000u);
 		}
 
 		PRUnitTestMethod(VectorConversion, float, double)
@@ -101,6 +123,69 @@ namespace pr::math::tests
 
 			auto h2 = F32toF16(-0.5f);
 			PR_EXPECT(F16toF32(h2) == -0.5f);
+		}
+		PRUnitTestMethod(RuntimeMatchesConstexpr)
+		{
+			struct F32Case
+			{
+				uint32_t f32_bits;
+				half_t half_bits;
+				uint32_t round_trip_bits;
+			};
+
+			// Use exact bit patterns so rounding, signed zero, subnormal, infinity, and quiet-NaN cases are all compared without depending on formatted literals.
+			auto const f32_cases = std::array
+			{
+				F32Case{0x00000000u, half_t{0x0000u}, 0x00000000u},
+				F32Case{0x80000000u, half_t{0x8000u}, 0x80000000u},
+				F32Case{0x3f800000u, half_t{0x3c00u}, 0x3f800000u},
+				F32Case{0xbf000000u, half_t{0xb800u}, 0xbf000000u},
+				F32Case{0x3e800000u, half_t{0x3400u}, 0x3e800000u},
+				F32Case{0x33800000u, half_t{0x0001u}, 0x33800000u},
+				F32Case{0x38800000u, half_t{0x0400u}, 0x38800000u},
+				F32Case{0x3f801000u, half_t{0x3c00u}, 0x3f800000u},
+				F32Case{0x3f801800u, half_t{0x3c01u}, 0x3f802000u},
+				F32Case{0x477fe000u, half_t{0x7bffu}, 0x477fe000u},
+				F32Case{0x47c35000u, half_t{0x7c00u}, 0x7f800000u},
+				F32Case{0x7f800000u, half_t{0x7c00u}, 0x7f800000u},
+				F32Case{0x7fc00000u, half_t{0x7e00u}, 0x7fc00000u},
+			};
+
+			for (auto const& test_case : f32_cases)
+			{
+				auto const value = std::bit_cast<float>(test_case.f32_bits);
+				auto const constexpr_half = F32toF16CT(value);
+				auto const runtime_half = F32toF16(value);
+				PR_EXPECT(constexpr_half == test_case.half_bits);
+				PR_EXPECT(runtime_half == test_case.half_bits);
+
+				auto const constexpr_round_trip = F16toF32CT(test_case.half_bits);
+				auto const runtime_round_trip = F16toF32(test_case.half_bits);
+				PR_EXPECT(std::bit_cast<uint32_t>(constexpr_round_trip) == test_case.round_trip_bits);
+				PR_EXPECT(std::bit_cast<uint32_t>(runtime_round_trip) == test_case.round_trip_bits);
+			}
+
+			struct F16Case
+			{
+				half_t half_bits;
+				uint32_t f32_bits;
+			};
+
+			// Decode-only coverage keeps the largest subnormal and signed special values checked even when they are not produced by the forward conversion inputs above.
+			auto const f16_cases = std::array
+			{
+				F16Case{half_t{0x03ffu}, 0x387fc000u},
+				F16Case{half_t{0xfc00u}, 0xff800000u},
+				F16Case{half_t{0xfe00u}, 0xffc00000u},
+			};
+
+			for (auto const& test_case : f16_cases)
+			{
+				auto const constexpr_value = F16toF32CT(test_case.half_bits);
+				auto const runtime_value = F16toF32(test_case.half_bits);
+				PR_EXPECT(std::bit_cast<uint32_t>(constexpr_value) == test_case.f32_bits);
+				PR_EXPECT(std::bit_cast<uint32_t>(runtime_value) == test_case.f32_bits);
+			}
 		}
 	};
 }

--- a/include/pr/math/tests/half_tests.h
+++ b/include/pr/math/tests/half_tests.h
@@ -62,6 +62,9 @@ namespace pr::math::tests
 			static_assert(fm == -0.5f);
 
 			static_assert(F32toF16(-0.0f) == half_t{0x8000u});
+			static_assert(F32toF16(std::bit_cast<float>(0x33000000u)) == half_t{0x0000u});
+			static_assert(F32toF16(std::bit_cast<float>(0x33000001u)) == half_t{0x0001u});
+			static_assert(F32toF16(std::bit_cast<float>(0x337fffffu)) == half_t{0x0001u});
 			static_assert(F32toF16(0x1.0p-24f) == half_t{0x0001u});
 			static_assert(F32toF16(0x1.0p-14f) == half_t{0x0400u});
 			static_assert(F32toF16(65504.0f) == half_t{0x7bffu});
@@ -69,6 +72,8 @@ namespace pr::math::tests
 			static_assert(std::bit_cast<uint32_t>(F16toF32(half_t{0x0001u})) == 0x33800000u);
 			static_assert(std::bit_cast<uint32_t>(F16toF32(half_t{0x03ffu})) == 0x387fc000u);
 			static_assert(std::bit_cast<uint32_t>(F16toF32(half_t{0x7e00u})) == 0x7fc00000u);
+			static_assert(std::bit_cast<uint32_t>(F16toF32(half_t{0x7c01u})) == 0x7fc02000u);
+			static_assert(std::bit_cast<uint32_t>(F16toF32(half_t{0xfc01u})) == 0xffc02000u);
 
 			// This reproduces the original regression: constexpr vector conversion must stay on the constexpr scalar path.
 			constexpr auto hv = F32toF16(Vec4<float>{1.0f, -0.5f, 0.25f, -0.0f});
@@ -141,6 +146,12 @@ namespace pr::math::tests
 				F32Case{0x3f800000u, half_t{0x3c00u}, 0x3f800000u},
 				F32Case{0xbf000000u, half_t{0xb800u}, 0xbf000000u},
 				F32Case{0x3e800000u, half_t{0x3400u}, 0x3e800000u},
+				F32Case{0x33000000u, half_t{0x0000u}, 0x00000000u},
+				F32Case{0x33000001u, half_t{0x0001u}, 0x33800000u},
+				F32Case{0x337fffffu, half_t{0x0001u}, 0x33800000u},
+				F32Case{0xb3000000u, half_t{0x8000u}, 0x80000000u},
+				F32Case{0xb3000001u, half_t{0x8001u}, 0xb3800000u},
+				F32Case{0xb37fffffu, half_t{0x8001u}, 0xb3800000u},
 				F32Case{0x33800000u, half_t{0x0001u}, 0x33800000u},
 				F32Case{0x38800000u, half_t{0x0400u}, 0x38800000u},
 				F32Case{0x3f801000u, half_t{0x3c00u}, 0x3f800000u},
@@ -175,6 +186,8 @@ namespace pr::math::tests
 			auto const f16_cases = std::array
 			{
 				F16Case{half_t{0x03ffu}, 0x387fc000u},
+				F16Case{half_t{0x7c01u}, 0x7fc02000u},
+				F16Case{half_t{0xfc01u}, 0xffc02000u},
 				F16Case{half_t{0xfc00u}, 0xff800000u},
 				F16Case{half_t{0xfe00u}, 0xffc00000u},
 			};

--- a/include/pr/math/types/half.h
+++ b/include/pr/math/types/half.h
@@ -12,6 +12,23 @@ namespace pr::math
 	using half_t = unsigned short;
 	using Half4 = Vec4<half_t>;
 
+	namespace half_impl
+	{
+		// Round an integer right shift using IEEE round-to-nearest-even so the constexpr path matches the runtime F16C conversion.
+		constexpr uint32_t RoundShiftRightNearestEven(uint32_t value, uint32_t shift) noexcept
+		{
+			if (shift == 0)
+				return value;
+
+			auto const truncated = value >> shift;
+			auto const remainder_mask = (uint32_t{1} << shift) - 1u;
+			auto const remainder = value & remainder_mask;
+			auto const halfway = uint32_t{1} << (shift - 1u);
+			auto const round_up = remainder > halfway || (remainder == halfway && (truncated & 1u) != 0u);
+			return truncated + static_cast<uint32_t>(round_up);
+		}
+	}
+
 	#define PR_MATH_DEFINE_TYPE(element)\
 	template <> struct vector_traits<Vec4<element>>\
 		: vector_traits_base<element, element, 4>\
@@ -25,63 +42,96 @@ namespace pr::math
 	PR_MATH_DEFINE_TYPE(half_t);
 	#undef PR_MATH_DEFINE_TYPE
 
-	// Convert between 32-bit float (1s7e24m) and 16-bit float (1s5e10m) at compile time
+	// Convert a 32-bit float to IEEE binary16 during constant evaluation. The runtime path keeps using F16C so this code only needs to mirror the hardware bit pattern.
 	constexpr half_t F32toF16CT(float f32) noexcept
 	{
-		// see https://gist.github.com/martin-kallman/5049614 (Note comments though, Martin's implementation has a bug)
-		// see https://github.com/numpy/numpy/blob/master/numpy/core/src/npymath/halffloat.c#L466
+		auto const bits = std::bit_cast<uint32_t>(f32);
+		auto const sign_bits = static_cast<half_t>((bits >> 16) & 0x8000u);
+		auto const exponent_bits = static_cast<uint32_t>((bits >> 23) & 0xffu);
+		auto const mantissa_bits = static_cast<uint32_t>(bits & 0x007fffffu);
 
-		// Martin Kallman (mostly. Some parts nicked from numpy)
-		//
-		// Fast single-precision to half-precision floating point conversion
-		//  - Supports signed zero, denormals-as-zero (DAZ), flush-to-zero (FTZ),
-		//    clamp-to-max
-		//  - Does not support infinities or NaN
-		//  - Few, partially pipeline-able, non-branching instructions,
-		//  - Core operations ~10 clock cycles on modern x86-64
-		auto u = std::bit_cast<uint32_t>(f32);
-		auto t1 = static_cast<uint32_t>(u & 0x7fffffff);        // Non-sign bits
-		auto t2 = static_cast<uint32_t>(u & 0x80000000);        // Sign bit
-		auto t3 = static_cast<uint32_t>(u & 0x7f800000);        // Exponent
-		auto t4 = static_cast<uint32_t>(u & 0x007fffffu) >> 13; // NaN signal >> 13
+		// Preserve infinities and carry a quiet NaN payload into the half mantissa so constant evaluation classifies the same way as the F16C path.
+		if (exponent_bits == 0xffu)
+		{
+			if (mantissa_bits == 0u)
+				return static_cast<half_t>(sign_bits | 0x7c00u);
 
-		t1 >>= 13;                                     // Align mantissa on MSB
-		t2 >>= 16;                                     // Shift sign bit into position
-		t1 -= 0x1c000;                                 // Adjust bias
-		t1 = (t3 < 0x38800000) ? 0 : t1;               // Flush-to-zero
-		t1 = (t3 > 0x47000000) ? 0x7c00u : t1;         // Clamp-to-max (inf = 0x7c00u, max = 0x7bffu)
-		t1 = (t3 == 0x7f800000) ? (0x7c00u + t4) : t1; // NaN or Inf (t4 == 0)
-		t1 = (t3 == 0) ? 0 : t1;                       // Denormals-as-zero
-		t1 |= t2;                                      // Re-insert sign bit
-		return static_cast<half_t>(t1);
+			auto nan_payload = static_cast<half_t>(mantissa_bits >> 13);
+			nan_payload = static_cast<half_t>(nan_payload | 0x0200u);
+			return static_cast<half_t>(sign_bits | 0x7c00u | nan_payload);
+		}
+
+		// Float32 subnormals are far smaller than the binary16 range, so they only contribute the sign when rounded.
+		if (exponent_bits == 0u)
+			return sign_bits;
+
+		auto const exponent = static_cast<int>(exponent_bits) - 127;
+		if (exponent > 15)
+			return static_cast<half_t>(sign_bits | 0x7c00u);
+
+		auto const significand_bits = static_cast<uint32_t>(0x00800000u | mantissa_bits);
+		if (exponent >= -14)
+		{
+			// Round the 24-bit float significand into the 11-bit half significand, then fold any carry into the exponent.
+			auto rounded_significand = half_impl::RoundShiftRightNearestEven(significand_bits, 13);
+			auto half_exponent = static_cast<uint32_t>(exponent + 15);
+			if (rounded_significand == 0x0800u)
+			{
+				rounded_significand = 0x0400u;
+				++half_exponent;
+				if (half_exponent >= 0x1fu)
+					return static_cast<half_t>(sign_bits | 0x7c00u);
+			}
+
+			return static_cast<half_t>(sign_bits | (half_exponent << 10) | (rounded_significand & 0x03ffu));
+		}
+
+		// Values below the normal range become subnormals or signed zero, still using round-to-nearest-even.
+		if (exponent < -24)
+			return sign_bits;
+
+		auto rounded_mantissa = half_impl::RoundShiftRightNearestEven(significand_bits, static_cast<uint32_t>(-exponent - 1));
+		if (rounded_mantissa == 0x0400u)
+			return static_cast<half_t>(sign_bits | 0x0400u);
+
+		return static_cast<half_t>(sign_bits | rounded_mantissa);
 	}
+	// Convert an IEEE binary16 value to 32-bit float during constant evaluation so constexpr code sees the same categories and payload layout as the runtime path.
 	constexpr float F16toF32CT(half_t f16) noexcept
 	{
-		// Martin Kallman (mostly. Some parts nicked from numpy)
-		//
-		// Fast half-precision to single-precision floating point conversion
-		//  - Supports signed zero and denormals-as-zero (DAZ)
-		//  - Does not support infinities or NaN
-		//  - Few, partially pipeline-able, non-branching instructions,
-		//  - Core operations ~6 clock cycles on modern x86-64
+		auto const sign_bits = static_cast<uint32_t>(f16 & 0x8000u) << 16;
+		auto const exponent_bits = static_cast<uint32_t>((f16 >> 10) & 0x1fu);
+		auto const mantissa_bits = static_cast<uint32_t>(f16 & 0x03ffu);
 
-		auto t1 = static_cast<uint32_t>(f16 & 0x7fff);      // Non-sign bits
-		auto t2 = static_cast<uint32_t>(f16 & 0x8000);      // Sign bit
-		auto t3 = static_cast<uint32_t>(f16 & 0x7c00);      // Exponent
-		auto t4 = static_cast<uint32_t>(t1 - 0x7c00) << 13; // NaN signal
+		if (exponent_bits == 0x1fu)
+			return std::bit_cast<float>(sign_bits | 0x7f800000u | (mantissa_bits << 13));
 
-		t1 <<= 13;                                         // Align mantissa on MSB
-		t2 <<= 16;                                         // Shift sign bit into position
-		t1 += 0x38000000;                                  // Adjust bias
-		t1 = t3 == 0 ? 0 : t1;                             // Denormals-as-zero
-		t1 = t3 >= 0x7c00u ? 0x7f800000u + t4 : t1;        // NaN or Inf (t4 == 0)
-		t1 |= t2;                                          // Re-insert sign bit
-		return std::bit_cast<float>(t1);
+		if (exponent_bits != 0u)
+			return std::bit_cast<float>(sign_bits | ((exponent_bits + 112u) << 23) | (mantissa_bits << 13));
+
+		if (mantissa_bits == 0u)
+			return std::bit_cast<float>(sign_bits);
+
+		// Binary16 subnormals need renormalising before the float exponent can be reconstructed.
+		auto normalised_mantissa = mantissa_bits;
+		auto exponent = -14;
+		while ((normalised_mantissa & 0x0400u) == 0u)
+		{
+			normalised_mantissa <<= 1;
+			--exponent;
+		}
+		normalised_mantissa &= 0x03ffu;
+		return std::bit_cast<float>(sign_bits | (static_cast<uint32_t>(exponent + 127) << 23) | (normalised_mantissa << 13));
 	}
 
-	// Convert between 32-bit float (1s7e24m) and 16-bit float (1s5e10m)
-	inline half_t F32toF16(float f32) noexcept
+	// Convert between 32-bit float (1s8e23m) and IEEE binary16 (1s5e10m). Constant evaluation uses the scalar implementation while runtime keeps the F16C fast path.
+	inline constexpr half_t F32toF16(float f32) noexcept
 	{
+		if consteval
+		{
+			return F32toF16CT(f32);
+		}
+
 		#if PR_MATHS_USE_INTRINSICS
 		auto vecf32 = _mm_set_ps1(f32);
 		auto vecf16 = _mm_cvtps_ph(vecf32, _MM_FROUND_TO_NEAREST_INT);
@@ -90,8 +140,14 @@ namespace pr::math
 		return F32toF16CT(f32);
 		#endif
 	}
-	inline float F16toF32(half_t f16) noexcept
+	// Convert between IEEE binary16 (1s5e10m) and 32-bit float (1s8e23m). The runtime path still uses F16C where available.
+	inline constexpr float F16toF32(half_t f16) noexcept
 	{
+		if consteval
+		{
+			return F16toF32CT(f16);
+		}
+
 		#if PR_MATHS_USE_INTRINSICS
 		auto vecf16 = _mm_set_epi16(0, 0, 0, 0, 0, 0, 0, static_cast<short>(f16));
 		auto vecf32 = _mm_cvtph_ps(vecf16);
@@ -102,10 +158,8 @@ namespace pr::math
 	}
 
 	// Return 'v' converted to half size floats
-	template <VectorTypeFP Vec> constexpr Half4 pr_vectorcall F32toF16(Vec v) noexcept
+	template <VectorTypeFP Vec> requires (vector_traits<std::remove_cv_t<Vec>>::dimension == 4) constexpr Half4 pr_vectorcall F32toF16(Vec v) noexcept
 	{
-		using vt = vector_traits<Vec>;
-
 		auto fallback = [&]() constexpr { return Half4{ F32toF16(static_cast<float>(vec(v).x)), F32toF16(static_cast<float>(vec(v).y)), F32toF16(static_cast<float>(vec(v).z)), F32toF16(static_cast<float>(vec(v).w)) }; };
 		if consteval
 		{
@@ -126,7 +180,7 @@ namespace pr::math
 	}
 
 	// Return 'v' to full size floats/doubles
-	template <VectorTypeFP Vec> constexpr Vec pr_vectorcall F16toF32(Half4 v) noexcept
+	template <VectorTypeFP Vec> requires (vector_traits<std::remove_cv_t<Vec>>::dimension == 4) constexpr Vec pr_vectorcall F16toF32(Half4 v) noexcept
 	{
 		using vt = vector_traits<Vec>;
 
@@ -255,18 +309,18 @@ namespace pr::math::tests
 		PRUnitTestMethod(ConstexprTests)
 		{
 			// Constexpr round-trip
-			constexpr auto h = F32toF16CT(1.0f);
-			constexpr auto f = F16toF32CT(h);
+			constexpr auto h = F32toF16(1.0f);
+			constexpr auto f = F16toF32(h);
 			static_assert(f == 1.0f);
 
 			// Constexpr zero
-			constexpr auto hz = F32toF16CT(0.0f);
-			constexpr auto fz = F16toF32CT(hz);
+			constexpr auto hz = F32toF16(0.0f);
+			constexpr auto fz = F16toF32(hz);
 			static_assert(fz == 0.0f);
 
 			// Constexpr negative
-			constexpr auto hn = F32toF16CT(-1.0f);
-			constexpr auto fn = F16toF32CT(hn);
+			constexpr auto hn = F32toF16(-1.0f);
+			constexpr auto fn = F16toF32(hn);
 			static_assert(fn == -1.0f);
 		}
 		PRUnitTestMethod(BoundaryTests)

--- a/include/pr/math/types/half.h
+++ b/include/pr/math/types/half.h
@@ -87,7 +87,8 @@ namespace pr::math
 		}
 
 		// Values below the normal range become subnormals or signed zero, still using round-to-nearest-even.
-		if (exponent < -24)
+		// Keep exponent -25 values in the rounded path because numbers above the halfway point round up to the smallest subnormal.
+		if (exponent < -25)
 			return sign_bits;
 
 		auto rounded_mantissa = half_impl::RoundShiftRightNearestEven(significand_bits, static_cast<uint32_t>(-exponent - 1));
@@ -104,7 +105,13 @@ namespace pr::math
 		auto const mantissa_bits = static_cast<uint32_t>(f16 & 0x03ffu);
 
 		if (exponent_bits == 0x1fu)
-			return std::bit_cast<float>(sign_bits | 0x7f800000u | (mantissa_bits << 13));
+		{
+			auto quiet_mantissa = mantissa_bits;
+			if (quiet_mantissa != 0u)
+				quiet_mantissa |= 0x0200u;
+
+			return std::bit_cast<float>(sign_bits | 0x7f800000u | (quiet_mantissa << 13));
+		}
 
 		if (exponent_bits != 0u)
 			return std::bit_cast<float>(sign_bits | ((exponent_bits + 112u) << 23) | (mantissa_bits << 13));


### PR DESCRIPTION
## Summary
- make the public half conversion APIs constexpr-aware so vector constexpr evaluation stays on the scalar compile-time path
- replace the constexpr float/half packing with IEEE binary16 round-to-nearest-even handling for normals, subnormals, infinities, and quiet NaNs
- add compile-time assertions plus runtime constexpr-vs-F16C consistency coverage for representative scalar and vector cases

## Validation
- compiled the original constexpr auto value = F32toF16(Vec4<float>{1, -0.5f, 0.25f, 0}) repro successfully with VS 2026 cl
- built projects\tests\unittests\unittests.vcxproj (Debug x64, v145) and ran all native unit tests