### PR TITLE
Fix IsNaN aggregation for Vec8 and Mat6x8

### DIFF
--- a/include/pr/math/tests/matrix6x8_tests.h
+++ b/include/pr/math/tests/matrix6x8_tests.h
@@ -87,6 +87,54 @@ namespace pr::math::tests
 			auto I = M * M_inv;
 			PR_EXPECT(FEql(I, mat6_t::Identity()));
 		}
+
+		// Verify that Mat6x8 combines its Mat3x3 blocks with the same any/all NaN contract as the generic matrix helpers.
+		PRUnitTestMethod(IsNaNAggregation, float, double)
+		{
+			using mat3_t = Mat3x3<T>;
+			using mat6_t = Mat6x8<T, void, void>;
+
+			auto const nan = std::numeric_limits<T>::quiet_NaN();
+
+			auto const finite = mat6_t::Identity();
+			auto const one_component_nan = mat6_t{
+				mat3_t{
+					Vec3<T>{nan, T(0), T(0)},
+					Vec3<T>{T(0), T(1), T(0)},
+					Vec3<T>{T(0), T(0), T(1)}
+				},
+				mat3_t::Zero(),
+				mat3_t::Zero(),
+				mat3_t::Identity()
+			};
+			auto const mixed_blocks = mat6_t{
+				mat3_t{nan},
+				mat3_t{
+					Vec3<T>{nan, T(0), T(0)},
+					Vec3<T>{T(0), T(1), T(0)},
+					Vec3<T>{T(0), T(0), T(1)}
+				},
+				mat3_t::Zero(),
+				mat3_t::Identity()
+			};
+			auto const all_nan = mat6_t{
+				mat3_t{nan},
+				mat3_t{nan},
+				mat3_t{nan},
+				mat3_t{nan}
+			};
+
+			// 'any=true' succeeds when any block contains at least one NaN.
+			PR_EXPECT(!IsNaN(finite, true));
+			PR_EXPECT(IsNaN(one_component_nan, true));
+			PR_EXPECT(IsNaN(mixed_blocks, true));
+
+			// 'any=false' succeeds only when every block reports that all of its elements are NaN.
+			PR_EXPECT(!IsNaN(finite, false));
+			PR_EXPECT(!IsNaN(one_component_nan, false));
+			PR_EXPECT(!IsNaN(mixed_blocks, false));
+			PR_EXPECT(IsNaN(all_nan, false));
+		}
 	};
 }
 #endif

--- a/include/pr/math/tests/vector8_tests.h
+++ b/include/pr/math/tests/vector8_tests.h
@@ -108,6 +108,43 @@ namespace pr::math::tests
 			auto R = Reflect(v, n);
 			PR_EXPECT(FEql(r, R));
 		}
+
+		// Verify that Vec8 preserves the underlying Vec4 any/all NaN contract across both sub-vectors.
+		PRUnitTestMethod(IsNaNAggregation, float, double)
+		{
+			using vec8_t = Vec8<T, void>;
+			using vec4_t = Vec4<T>;
+
+			auto const nan = std::numeric_limits<T>::quiet_NaN();
+
+			auto const finite = vec8_t{
+				vec4_t{T(1), T(2), T(3), T(4)},
+				vec4_t{T(5), T(6), T(7), T(8)}
+			};
+			auto const angular_nan = vec8_t{
+				vec4_t{nan, nan, nan, nan},
+				finite.lin
+			};
+			auto const mixed_blocks = vec8_t{
+				vec4_t{nan, T(2), T(3), T(4)},
+				vec4_t{nan, nan, nan, nan}
+			};
+			auto const all_nan = vec8_t{
+				vec4_t{nan, nan, nan, nan},
+				vec4_t{nan, nan, nan, nan}
+			};
+
+			// 'any=true' succeeds when either sub-vector contains a NaN.
+			PR_EXPECT(!IsNaN(finite, true));
+			PR_EXPECT(IsNaN(angular_nan, true));
+			PR_EXPECT(IsNaN(mixed_blocks, true));
+
+			// 'any=false' succeeds only when both sub-vectors report that all of their elements are NaN.
+			PR_EXPECT(!IsNaN(finite, false));
+			PR_EXPECT(!IsNaN(angular_nan, false));
+			PR_EXPECT(!IsNaN(mixed_blocks, false));
+			PR_EXPECT(IsNaN(all_nan, false));
+		}
 	};
 }
 #endif

--- a/include/pr/math/types/matrix6x8.h
+++ b/include/pr/math/types/matrix6x8.h
@@ -281,11 +281,9 @@ namespace pr::math
 	template <ScalarType S, typename A, typename B>
 	constexpr bool pr_vectorcall IsNaN(Mat6x8<S, A, B> m, bool any = true) noexcept // false = all
 	{
-		return
-			IsNaN(m.m00, any) &&
-			IsNaN(m.m01, any) &&
-			IsNaN(m.m10, any) &&
-			IsNaN(m.m11, any);
+		return any
+			? IsNaN(m.m00, true) || IsNaN(m.m01, true) || IsNaN(m.m10, true) || IsNaN(m.m11, true)
+			: IsNaN(m.m00, false) && IsNaN(m.m01, false) && IsNaN(m.m10, false) && IsNaN(m.m11, false);
 	}
 
 	// Return the transpose of a spatial matrix

--- a/include/pr/math/types/vector8.h
+++ b/include/pr/math/types/vector8.h
@@ -238,7 +238,9 @@ namespace pr::math
 	template <ScalarType S, typename T>
 	constexpr bool pr_vectorcall IsNaN(Vec8<S, T> v, bool any = true) noexcept // false = all
 	{
-		return IsNaN(v.ang, any) || IsNaN(v.lin, any);
+		return any
+			? IsNaN(v.ang, true) || IsNaN(v.lin, true)
+			: IsNaN(v.ang, false) && IsNaN(v.lin, false);
 	}
 
 	// Project a vector onto an axis. Loosely "dot(vec,axis)*axis"


### PR DESCRIPTION
## Summary
- fix `Vec8::IsNaN` so `any=false` now requires both `Vec4` halves to report all-NaN, while `any=true` still succeeds if either half contains a NaN
- fix `Mat6x8::IsNaN` so `any=true` now succeeds if any `Mat3x3` block contains a NaN, while `any=false` still requires every block to be all-NaN
- add focused native unit coverage for both helpers covering `any=true`, `any=false`, and mixed sub-block cases

## Validation
- built `sdk\lua\lua.vcxproj`, `projects\rylogic\physics\physics.vcxproj`, `projects\rylogic\view3d-12\view3d-12.vcxproj`, and `projects\tests\unittests\unittests.vcxproj` with VS2026 MSBuild (`Debug|x64`)
- ran `projects\tests\unittests\obj\x64\Debug\unittests.exe` (`All 1012 unit tests passed`)