### PR TITLE
Fix RotationAt angular acceleration displacement

### DIFF
--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -4040,8 +4040,11 @@ namespace pr::math
 		// and angular acceleration are parallel or angular acceleration is zero.
 		if (LengthSq(Cross(avel, aacc)) < tiny<S>)
 		{
-			auto w = avel + aacc * time;
-			return ExpMap3x3<Mat>(w * time) * ori;
+			// Integrate w(t) = w0 + a*t exactly while the rotation axis is fixed.
+			// The result is w0*t + 0.5*a*t^2, not the final angular velocity scaled by time.
+			auto const dt = static_cast<S>(time);
+			auto const ang_disp = (avel + S(0.5) * aacc * dt) * dt;
+			return ExpMap3x3<Mat>(ang_disp) * ori;
 		}
 		else
 		{

--- a/include/pr/math/tests/function_tests.h
+++ b/include/pr/math/tests/function_tests.h
@@ -2049,16 +2049,35 @@ namespace pr::math::tests
 			using vt = vector_traits<mat_t>;
 			using S = typename vt::element_t;
 			using Vec = typename vt::component_t;
+			auto constexpr tol = S(0.001);
 
-			// Zero angular velocity and acceleration — orientation unchanged
-			auto ori = Identity<mat_t>();
-			auto result = RotationAt(0.0f, ori, Vec(S(0)), Vec(S(0)));
-			PR_EXPECT(FEql(result, ori));
+			// Compare against the exact angular displacement integral for the fixed-axis cases.
+			auto expect_parallel = [&](float time, Vec avel, Vec aacc)
+			{
+				auto const dt = static_cast<S>(time);
+				auto const expected_disp = (avel + S(0.5) * aacc * dt) * dt;
+				auto const actual = RotationAt(time, Identity<mat_t>(), avel, aacc);
 
-			// Constant angular velocity about Z, zero acceleration
-			auto avel = Vec(S(0), S(0), S(1)); // 1 rad/s about Z
-			auto R1 = RotationAt(0.0f, Identity<mat_t>(), avel, Vec(S(0)));
-			PR_EXPECT(IsOrthonormal(R1));
+				PR_EXPECT(IsOrthonormal(actual));
+				PR_EXPECT(FEqlAbsolute<Vec>(LogMap3x3(actual), expected_disp, tol));
+			};
+
+			// Zero time should preserve the starting orientation.
+			auto const ori = Rotation<mat_t>(Vec::XAxis(), S(0.25));
+			auto const unchanged = RotationAt(0.0f, ori, Vec::ZAxis(), Vec(S(0), S(0), S(2)));
+			PR_EXPECT(FEql(unchanged, ori));
+
+			// Zero angular acceleration should reduce to constant angular velocity.
+			expect_parallel(1.0f, Vec(S(0), S(0), S(1)), Vec(S(0)));
+
+			// Parallel angular acceleration should integrate to 0.5*a*t^2 from rest.
+			expect_parallel(1.0f, Vec(S(0)), Vec(S(0), S(0), S(2)));
+
+			// Non-zero initial angular velocity should add linearly to the quadratic term.
+			expect_parallel(1.0f, Vec(S(0), S(0), S(1)), Vec(S(0), S(0), S(2)));
+
+			// Negative time should follow the same integral and support exact cancellation cases.
+			expect_parallel(-1.0f, Vec(S(0), S(0), S(1)), Vec(S(0), S(0), S(2)));
 		}
 
 		// ---- Lerp (functions.h line ~1554) ----

--- a/include/pr/math/tests/quaternion_tests.h
+++ b/include/pr/math/tests/quaternion_tests.h
@@ -205,6 +205,52 @@ namespace pr::math::tests
 			auto q_zero = math::Scale(q, T(0));
 			PR_EXPECT(FEqlOrientation(q_zero, Identity<Quat>(), T(0.001)));
 		}
+
+		PRUnitTestMethod(RotationAt, float, double)
+		{
+			using Quat = Quat<T>;
+			using Vec3 = Vec3<T>;
+			using Vec4 = Vec4<T>;
+			using Mat3x3 = Mat3x3<T>;
+			auto constexpr tol = T(0.001);
+
+			// Compare against the exact angular displacement integral for the fixed-axis cases.
+			auto expect_parallel = [&](float time, Vec3 avel, Vec3 aacc)
+			{
+				auto const dt = static_cast<T>(time);
+				auto const expected_disp = (avel + T(0.5) * aacc * dt) * dt;
+				auto const actual = math::RotationAt(time, Identity<Quat>(), avel, aacc);
+				auto const actual_disp = LogMap<Vec3>(actual) * T(2);
+
+				PR_EXPECT(FEqlAbsolute<Vec3>(actual_disp, expected_disp, tol));
+			};
+
+			// Zero time should preserve the starting orientation.
+			auto const ori = Quat(Vec4::XAxis(), T(0.25));
+			auto const unchanged = math::RotationAt(0.0f, ori, Vec3::ZAxis(), Vec3(T(0), T(0), T(2)));
+			PR_EXPECT(FEqlOrientation(unchanged, ori, tol));
+
+			// Zero angular acceleration should reduce to constant angular velocity.
+			expect_parallel(1.0f, Vec3(T(0), T(0), T(1)), Vec3(T(0)));
+
+			// Parallel angular acceleration should integrate to 0.5*a*t^2 from rest.
+			expect_parallel(1.0f, Vec3(T(0)), Vec3(T(0), T(0), T(2)));
+
+			// Non-zero initial angular velocity should add linearly to the quadratic term.
+			expect_parallel(1.0f, Vec3(T(0), T(0), T(1)), Vec3(T(0), T(0), T(2)));
+
+			// Negative time should follow the same integral and support exact cancellation cases.
+			expect_parallel(-1.0f, Vec3(T(0), T(0), T(1)), Vec3(T(0), T(0), T(2)));
+
+			// Matrix and quaternion paths should agree for the non-parallel SPIRAL(6) integration case.
+			auto const time_np = 0.35f;
+			auto const avel_np = Vec3(T(0.7), T(-0.2), T(0.4));
+			auto const aacc_np = Vec3(T(-0.3), T(0.6), T(0.1));
+			auto const rot_q = math::RotationAt(time_np, ori, avel_np, aacc_np);
+			auto const rot_m = math::RotationAt(time_np, ToMatrix<Mat3x3>(ori), avel_np, aacc_np);
+			PR_EXPECT(FEqlOrientation(rot_q, ToQuat<Quat>(rot_m), tol));
+		}
+
 		PRUnitTestMethod(FEqlOrientation, float, double)
 		{
 			using Quat = Quat<T>;

--- a/include/pr/math/types/quaternion.h
+++ b/include/pr/math/types/quaternion.h
@@ -393,8 +393,11 @@ namespace pr::math
 		// and angular acceleration are parallel or angular acceleration is zero.
 		if (LengthSq(Cross(avel, aacc)) < tiny<S>)
 		{
-			auto w = avel + aacc * time;
-			return ExpMap(S(0.5) * w * time) * ori;
+			// Integrate w(t) = w0 + a*t exactly while the rotation axis is fixed.
+			// Quaternion exp-map expects half-angle magnitude, so halve the angular displacement.
+			auto const dt = static_cast<S>(time);
+			auto const ang_disp = (avel + S(0.5) * aacc * dt) * dt;
+			return ExpMap<Quat>(S(0.5) * ang_disp) * ori;
 		}
 		else
 		{
@@ -411,11 +414,11 @@ namespace pr::math
 			auto w1 = avel + aacc * c2 * time;
 			auto w2 = avel + aacc * c3 * time;
 
-			auto u0 = ExpMap<Vec>(S(0.5) * w0 * time / S(3));
-			auto u1 = ExpMap<Vec>(S(0.5) * w1 * time / S(3));
-			auto u2 = ExpMap<Vec>(S(0.5) * w2 * time / S(3));
+			auto u0 = ExpMap<Quat>(S(0.5) * w0 * time / S(3));
+			auto u1 = ExpMap<Quat>(S(0.5) * w1 * time / S(3));
+			auto u2 = ExpMap<Quat>(S(0.5) * w2 * time / S(3));
 
-			return u2 * u1 * u0 * ori; // needs testing
+			return u2 * u1 * u0 * ori; // Compose the three Gauss-Legendre sub-steps in time order.
 		}
 	}
 


### PR DESCRIPTION
## Summary
- fix the fixed-axis `RotationAt` shortcut to integrate angular displacement as `w0*t + 0.5*a*t^2` for both matrix and quaternion implementations
- keep the SPIRAL(6) nonparallel integration path intact while fixing the quaternion `ExpMap` instantiations
- add focused native matrix/quaternion tests for zero time, zero acceleration, parallel acceleration, nonzero initial velocity, negative time, and matrix/quaternion agreement

## Reproduction
- current-main native probe from identity with `avel=(0,0,0)`, `aacc=(0,0,2)`, `time=1` produced matrix log-map `z = 2` instead of the expected `z = 1`
- the quaternion fixed-axis path had the same displacement error, and its `ExpMap` calls were not explicitly instantiated

## Validation
- `MSBuild projects\\tests\\unittests\\unittests.vcxproj /p:Configuration=Debug /p:Platform=x64` -> all 1011 native unit tests passed
- `MSBuild projects\\rylogic\\view3d-12\\view3d-12.vcxproj /p:Configuration=Debug /p:Platform=x64`
- `MSBuild projects\\rylogic\\view3d-12\\view3d-12.dll.vcxproj /p:Configuration=Debug /p:Platform=x64`