### PR TITLE
Fix Matrix::resize data loss when component count changes with local buffer

### DIFF
--- a/include/pr/math/tests/matrix_tests.h
+++ b/include/pr/math/tests/matrix_tests.h
@@ -229,11 +229,8 @@ namespace pr::math::tests
 
 		PRUnitTestMethod(ResizePreserveData)
 		{
-			// Regression: local→local component-count change.
-			// Both old (2×2=4) and new (2×3=6) fit in LocalBufCount=16, so both live in m_buf.
-			// The old code memset-zeroed m_buf before the per-vector copies read from it,
-			// returning all zeros. Reproduces: Matrix<double>(2,2,{1,2,3,4}).resize(2,3,true)
-			// should give rows {1,2,0} and {3,4,0}, not {0,0,0}.
+			// local→local: component count increases, both layouts fit in m_buf.
+			// 2×2 → 2×3: existing elements stay at their per-vector positions; new column is zeroed.
 			{
 				auto m = Matrix<double>(2, 2, {1.0, 2.0, 3.0, 4.0});
 				PR_EXPECT(m.local());
@@ -244,10 +241,8 @@ namespace pr::math::tests
 				PR_EXPECT(m(1,0) == 3.0 && m(1,1) == 4.0 && m(1,2) == 0.0);
 			}
 
-			// local→local: same total element count, component count changes (local alias).
-			// 2×3 → 3×2: both 6 elements, both local (6 < 16). The old code aliased src/dst on
-			// m_buf; memset wiped the source before copying, returning all zeros. With the fix,
-			// the top-left 2×2 corner (min_vecs=2, min_cmps=2) is preserved correctly.
+			// local→local: same total element count, different component count (reshape).
+			// 2×3 → 3×2: the top-left 2×2 corner of logical positions is preserved; new row is zeroed.
 			{
 				auto m = Matrix<double>(2, 3, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
 				PR_EXPECT(m.local());
@@ -259,7 +254,7 @@ namespace pr::math::tests
 				PR_EXPECT(m(2,0) == 0.0 && m(2,1) == 0.0); // new row is zeroed
 			}
 
-			// local→local: shrinking component count.
+			// local→local: component count decreases; only the min-corner elements are kept.
 			{
 				auto m = Matrix<double>(2, 3, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
 				m.resize(2, 2, true);
@@ -269,8 +264,7 @@ namespace pr::math::tests
 			}
 
 			// local→heap: component count grows past LocalBufCount=16.
-			// 4×3=12 → 4×5=20: new buffer is heap-allocated, no aliasing. Fix must not
-			// regress this case.
+			// 4×3=12 → 4×5=20: new buffer is heap-allocated.
 			{
 				auto m = Matrix<double>(4, 3, {1,2,3, 4,5,6, 7,8,9, 10,11,12});
 				PR_EXPECT(m.local());
@@ -281,8 +275,8 @@ namespace pr::math::tests
 				PR_EXPECT(m(3,0)==10 && m(3,1)==11 && m(3,2)==12 && m(3,3)==0 && m(3,4)==0);
 			}
 
-			// heap→local: component count shrinks back below LocalBufCount=16.
-			// 4×5=20 → 4×3=12: new buffer is m_buf, old is heap, no aliasing.
+			// heap→local: component count shrinks below LocalBufCount=16.
+			// 4×5=20 → 4×3=12: new buffer is m_buf; first three columns of each row are preserved.
 			{
 				auto m = Matrix<double>(4, 5, {1,2,3,4,5, 6,7,8,9,10, 11,12,13,14,15, 16,17,18,19,20});
 				PR_EXPECT(!m.local());
@@ -293,9 +287,8 @@ namespace pr::math::tests
 				PR_EXPECT(m(3,0)==16 && m(3,1)==17 && m(3,2)==18);
 			}
 
-			// heap→heap same-count reshape: 5×4=20 → 4×5=20, both heap (20 > LocalBufCount=16).
-			// Previously the 'same count → reuse buffer' shortcut aliased src and dst on heap,
-			// causing all-zeros output. The fix allocates a fresh heap buffer for this case.
+			// heap→heap: same total element count, different component count, both on heap.
+			// 5×4=20 → 4×5=20: each row gets a new zero column; the fifth source row is dropped.
 			{
 				auto m = Matrix<double>(5, 4);
 				int v = 1;
@@ -308,7 +301,7 @@ namespace pr::math::tests
 				PR_EXPECT(!m.local());
 				PR_EXPECT(m.vecs() == 4 && m.cmps() == 5);
 
-				// Original row r had elements [r*4+1 .. r*4+4] followed by a new zero column.
+				// Each row has four preserved elements followed by a new zero column.
 				for (int r = 0; r != 4; ++r)
 				{
 					for (int c = 0; c != 4; ++c)
@@ -318,7 +311,7 @@ namespace pr::math::tests
 				}
 			}
 
-			// preserve_data = false: entire new buffer must be zeroed regardless of old data.
+			// preserve_data=false: all elements are zeroed regardless of existing content.
 			{
 				auto m = Matrix<double>(2, 2, {1.0, 2.0, 3.0, 4.0});
 				m.resize(2, 3, false);
@@ -327,7 +320,7 @@ namespace pr::math::tests
 					PR_EXPECT(v == 0.0);
 			}
 
-			// resize to zero: no crash, size reports zero.
+			// resize to zero dimensions: no crash, size reports zero.
 			{
 				auto m = Matrix<double>(2, 2, {1.0, 2.0, 3.0, 4.0});
 				m.resize(0, 0);

--- a/include/pr/math/tests/matrix_tests.h
+++ b/include/pr/math/tests/matrix_tests.h
@@ -227,6 +227,114 @@ namespace pr::math::tests
 			}
 		}
 
+		PRUnitTestMethod(ResizePreserveData)
+		{
+			// Regression: local→local component-count change.
+			// Both old (2×2=4) and new (2×3=6) fit in LocalBufCount=16, so both live in m_buf.
+			// The old code memset-zeroed m_buf before the per-vector copies read from it,
+			// returning all zeros. Reproduces: Matrix<double>(2,2,{1,2,3,4}).resize(2,3,true)
+			// should give rows {1,2,0} and {3,4,0}, not {0,0,0}.
+			{
+				auto m = Matrix<double>(2, 2, {1.0, 2.0, 3.0, 4.0});
+				PR_EXPECT(m.local());
+				m.resize(2, 3, true);
+				PR_EXPECT(m.vecs() == 2 && m.cmps() == 3);
+				PR_EXPECT(m.local());
+				PR_EXPECT(m(0,0) == 1.0 && m(0,1) == 2.0 && m(0,2) == 0.0);
+				PR_EXPECT(m(1,0) == 3.0 && m(1,1) == 4.0 && m(1,2) == 0.0);
+			}
+
+			// local→local: same total element count, component count changes (local alias).
+			// 2×3 → 3×2: both 6 elements, both local (6 < 16). The old code aliased src/dst on
+			// m_buf; memset wiped the source before copying, returning all zeros. With the fix,
+			// the top-left 2×2 corner (min_vecs=2, min_cmps=2) is preserved correctly.
+			{
+				auto m = Matrix<double>(2, 3, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+				PR_EXPECT(m.local());
+				m.resize(3, 2, true);
+				PR_EXPECT(m.vecs() == 3 && m.cmps() == 2);
+				PR_EXPECT(m.local());
+				PR_EXPECT(m(0,0) == 1.0 && m(0,1) == 2.0); // first two columns of old row 0
+				PR_EXPECT(m(1,0) == 4.0 && m(1,1) == 5.0); // first two columns of old row 1
+				PR_EXPECT(m(2,0) == 0.0 && m(2,1) == 0.0); // new row is zeroed
+			}
+
+			// local→local: shrinking component count.
+			{
+				auto m = Matrix<double>(2, 3, {1.0, 2.0, 3.0, 4.0, 5.0, 6.0});
+				m.resize(2, 2, true);
+				PR_EXPECT(m.vecs() == 2 && m.cmps() == 2);
+				PR_EXPECT(m(0,0) == 1.0 && m(0,1) == 2.0);
+				PR_EXPECT(m(1,0) == 4.0 && m(1,1) == 5.0);
+			}
+
+			// local→heap: component count grows past LocalBufCount=16.
+			// 4×3=12 → 4×5=20: new buffer is heap-allocated, no aliasing. Fix must not
+			// regress this case.
+			{
+				auto m = Matrix<double>(4, 3, {1,2,3, 4,5,6, 7,8,9, 10,11,12});
+				PR_EXPECT(m.local());
+				m.resize(4, 5, true);
+				PR_EXPECT(!m.local());
+				PR_EXPECT(m.vecs() == 4 && m.cmps() == 5);
+				PR_EXPECT(m(0,0)==1 && m(0,1)==2 && m(0,2)==3 && m(0,3)==0 && m(0,4)==0);
+				PR_EXPECT(m(3,0)==10 && m(3,1)==11 && m(3,2)==12 && m(3,3)==0 && m(3,4)==0);
+			}
+
+			// heap→local: component count shrinks back below LocalBufCount=16.
+			// 4×5=20 → 4×3=12: new buffer is m_buf, old is heap, no aliasing.
+			{
+				auto m = Matrix<double>(4, 5, {1,2,3,4,5, 6,7,8,9,10, 11,12,13,14,15, 16,17,18,19,20});
+				PR_EXPECT(!m.local());
+				m.resize(4, 3, true);
+				PR_EXPECT(m.local());
+				PR_EXPECT(m.vecs() == 4 && m.cmps() == 3);
+				PR_EXPECT(m(0,0)==1  && m(0,1)==2  && m(0,2)==3);
+				PR_EXPECT(m(3,0)==16 && m(3,1)==17 && m(3,2)==18);
+			}
+
+			// heap→heap same-count reshape: 5×4=20 → 4×5=20, both heap (20 > LocalBufCount=16).
+			// Previously the 'same count → reuse buffer' shortcut aliased src and dst on heap,
+			// causing all-zeros output. The fix allocates a fresh heap buffer for this case.
+			{
+				auto m = Matrix<double>(5, 4);
+				int v = 1;
+				for (int r = 0; r != 5; ++r)
+					for (int c = 0; c != 4; ++c)
+						m(r, c) = double(v++);
+
+				PR_EXPECT(!m.local());
+				m.resize(4, 5, true);
+				PR_EXPECT(!m.local());
+				PR_EXPECT(m.vecs() == 4 && m.cmps() == 5);
+
+				// Original row r had elements [r*4+1 .. r*4+4] followed by a new zero column.
+				for (int r = 0; r != 4; ++r)
+				{
+					for (int c = 0; c != 4; ++c)
+						PR_EXPECT(m(r, c) == double(r*4 + c + 1));
+
+					PR_EXPECT(m(r, 4) == 0.0);
+				}
+			}
+
+			// preserve_data = false: entire new buffer must be zeroed regardless of old data.
+			{
+				auto m = Matrix<double>(2, 2, {1.0, 2.0, 3.0, 4.0});
+				m.resize(2, 3, false);
+				PR_EXPECT(m.vecs() == 2 && m.cmps() == 3);
+				for (auto v : m.data())
+					PR_EXPECT(v == 0.0);
+			}
+
+			// resize to zero: no crash, size reports zero.
+			{
+				auto m = Matrix<double>(2, 2, {1.0, 2.0, 3.0, 4.0});
+				m.resize(0, 0);
+				PR_EXPECT(m.vecs() == 0 && m.cmps() == 0 && m.size() == 0);
+			}
+		}
+
 		PRUnitTestMethod(DotProduct)
 		{
 			auto a = Matrix<float>(1, 3, {1.0f, 2.0f, 3.0f});

--- a/include/pr/math/types/matrix.h
+++ b/include/pr/math/types/matrix.h
@@ -352,21 +352,27 @@ namespace pr::math
 		}
 
 		// Change the dimensions of the matrix.
+		// When preserve_data is true, each existing vector's elements are kept at their logical
+		// position; new slots are zeroed. When false, the entire new buffer is zeroed.
 		void resize(int vecs, int cmps, bool preserve_data = true) noexcept
 		{
 			if (m_transposed) std::swap(vecs, cmps);
 
-			// Check if a resize is needed
 			auto new_count = size_t(vecs * cmps);
 			auto old_count = size_t(m_vecs * m_cmps);
 			auto min_count = std::min(new_count, old_count);
-			auto min_vecs = std::min(vecs, m_vecs);
-			auto min_cmps = std::min(cmps, m_cmps);
-			
-			// Slocate buffer if necessary.
+			auto min_vecs  = std::min(vecs, m_vecs);
+			auto min_cmps  = std::min(cmps, m_cmps);
+
+			// Select the destination buffer.
+			// The 'reuse existing buffer' shortcut is only safe when the vector layout is
+			// unchanged (cmps == m_cmps): elements are contiguous and no reshuffling occurs.
+			// When the component count changes each vector must be copied individually, and
+			// source/destination cannot safely alias. For that path we always need a distinct
+			// buffer; large same-size reshapes get a fresh heap allocation here.
 			auto data =
-				new_count == old_count ? m_data :
-				new_count > LocalBufCount ? new S[new_count] :
+				(new_count == old_count && cmps == m_cmps) ? m_data :
+				new_count > size_t(LocalBufCount) ? new S[new_count] :
 				&m_buf[0];
 
 			// Copy/Initialise data
@@ -377,16 +383,33 @@ namespace pr::math
 			}
 			else if (cmps == m_cmps)
 			{
-				// Matrix elements are stored as contiguous vectors so adding/removing vectors does not invalidate existing data.
+				// Vector layout is unchanged: adding/removing whole vectors does not disturb
+				// existing elements, so a single bulk copy (when moving between buffers) and a
+				// tail-zeroing step are sufficient.
 				if (data != m_data) memcpy(data, m_data, sizeof(S) * min_count);
 				memset(data + min_count, 0, sizeof(S) * (new_count - min_count));
 			}
 			else
 			{
-				// Adding components requires copying per vector.
+				// Component count changes: each vector must be copied individually because the
+				// stride between vectors differs before and after the resize.
+				//
+				// Source/destination can still alias when both the old and new data fit in the
+				// local buffer (m_buf): zeroing the destination first would wipe the source.
+				// Snapshot the old data before zeroing in that case.
+				// (The large same-size-reshape alias is already broken above by allocating a
+				// fresh heap buffer, so snap only needs to cover the local-buffer case.)
+				S snap[LocalBufCount];
+				S* src = m_data;
+				if (data == m_data)
+				{
+					// Both old and new buffers are m_buf (old_count <= LocalBufCount by construction).
+					memcpy(snap, m_data, sizeof(S) * old_count);
+					src = snap;
+				}
 				memset(data, 0, sizeof(S) * new_count);
 				for (int i = 0; i != min_vecs; ++i)
-					memcpy(data + i*cmps, m_data + i*m_cmps, sizeof(S) * min_cmps);
+					memcpy(data + i*cmps, src + i*m_cmps, sizeof(S) * min_cmps);
 			}
 
 			// Update the members
@@ -394,7 +417,7 @@ namespace pr::math
 			m_cmps = cmps;
 			std::swap(m_data, data);
 
-			// Deallocate the old buffer
+			// Deallocate the old buffer if it was heap-allocated
 			if (data != m_data && data != &m_buf[0])
 				delete[] data;
 		}

--- a/include/pr/math/types/matrix.h
+++ b/include/pr/math/types/matrix.h
@@ -365,11 +365,10 @@ namespace pr::math
 			auto min_cmps  = std::min(cmps, m_cmps);
 
 			// Select the destination buffer.
-			// The 'reuse existing buffer' shortcut is only safe when the vector layout is
-			// unchanged (cmps == m_cmps): elements are contiguous and no reshuffling occurs.
-			// When the component count changes each vector must be copied individually, and
-			// source/destination cannot safely alias. For that path we always need a distinct
-			// buffer; large same-size reshapes get a fresh heap allocation here.
+			// Reusing the existing buffer is only safe when the vector layout is unchanged
+			// (cmps == m_cmps): all elements are contiguous and no per-vector reshuffling is
+			// needed. When the component count changes, a distinct source and destination are
+			// required for the per-vector copy below.
 			auto data =
 				(new_count == old_count && cmps == m_cmps) ? m_data :
 				new_count > size_t(LocalBufCount) ? new S[new_count] :
@@ -392,18 +391,15 @@ namespace pr::math
 			else
 			{
 				// Component count changes: each vector must be copied individually because the
-				// stride between vectors differs before and after the resize.
+				// per-vector stride differs between the old and new layout.
 				//
-				// Source/destination can still alias when both the old and new data fit in the
-				// local buffer (m_buf): zeroing the destination first would wipe the source.
-				// Snapshot the old data before zeroing in that case.
-				// (The large same-size-reshape alias is already broken above by allocating a
-				// fresh heap buffer, so snap only needs to cover the local-buffer case.)
+				// When both old and new data fit in m_buf, source and destination point to the
+				// same buffer. Snapshot the old elements before zeroing so the copies read intact data.
 				S snap[LocalBufCount];
 				S* src = m_data;
 				if (data == m_data)
 				{
-					// Both old and new buffers are m_buf (old_count <= LocalBufCount by construction).
+					// data == m_data == &m_buf[0]; old_count <= LocalBufCount by construction.
 					memcpy(snap, m_data, sizeof(S) * old_count);
 					src = snap;
 				}


### PR DESCRIPTION
## Problem

`Matrix::resize()` returned all-zeros when changing component count while data was stored in the local buffer (`m_buf`).

**Reproducer:**
```cpp
Matrix<double>(2,2,{1,2,3,4}).resize(2,3,true)
// Returns: {0,0,0, 0,0,0}  ← wrong
// Expected: rows {1,2,0} and {3,4,0}
```

## Root Cause

Two aliasing scenarios in the `else` branch of `resize()` (the per-vector copy path, triggered when `cmps != m_cmps`):

**1. local→local (primary bug):** Both old and new element counts fit within `LocalBufCount=16`, so both live in `m_buf`. The code set `data = &m_buf[0]` (same as `m_data`), then:
```cpp
memset(data, 0, sizeof(S) * new_count);          // Wiped m_buf (the source!)
for (int i = 0; i != min_vecs; ++i)
    memcpy(data + i*cmps, m_data + i*m_cmps, ...); // Read back zeros from m_buf
```

**2. heap→heap same-count reshape:** When `new_count == old_count`, the allocation shortcut set `data = m_data` on heap too. A reshape like 5×4→4×5 (20 elements > 16) triggered the same wipe-then-read-zeros bug.

## Fix

Two targeted changes to `resize()`:

**1. Tighten the 'reuse existing buffer' condition** (`matrix.h`, allocation line):
```cpp
// Before:
auto data = new_count == old_count ? m_data : ...;

// After: only reuse when layout is truly unchanged (no per-vector reshuffling)
auto data = (new_count == old_count && cmps == m_cmps) ? m_data : ...;
```
This breaks the heap→heap alias by allocating a fresh buffer for large same-size reshapes.

**2. Stack snapshot for local aliasing** (`matrix.h`, `else` branch):
```cpp
S snap[LocalBufCount];
S* src = m_data;
if (data == m_data)  // Both small enough to live in m_buf
{
    memcpy(snap, m_data, sizeof(S) * old_count);
    src = snap;
}
memset(data, 0, sizeof(S) * new_count);
for (int i = 0; i != min_vecs; ++i)
    memcpy(data + i*cmps, src + i*m_cmps, sizeof(S) * min_cmps);
```
When `data == m_data == &m_buf[0]`, old data is snapshotted to a 16-element stack array before the zeroing step. Per-vector copies then read from the snapshot.

## Storage Transitions Verified

| Transition | Mechanism | Alias? | Handled by |
|---|---|---|---|
| local→local | both ≤16, both `m_buf` | ✅ Yes | stack snap |
| local→heap | `new_count > 16`, fresh heap | ❌ No | N/A |
| heap→local | `data=m_buf`, `m_data=heap` | ❌ No | N/A |
| heap→heap different-count | fresh `new S[n]` | ❌ No | N/A |
| heap→heap same-count reshape | now gets fresh `new S[n]` | ✅ Fixed | allocation change |

## Tests Added (`matrix_tests.h`)

New `ResizePreserveData` test method covering:
- Primary bug reproduction: `Matrix<double>(2,2,{1,2,3,4}).resize(2,3,true)`
- Same-count local alias: `2×3 → 3×2`
- Shrinking component count (local)
- local→heap grow past `LocalBufCount`
- heap→local shrink
- heap→heap same-count reshape `5×4 → 4×5`
- `preserve_data=false` (entire buffer zeroed)
- Resize to zero

## Validation

Built and ran `projects/tests/unittests/unittests.vcxproj` Debug x64 with VS2026/v145 toolset.

```
**** UnitTest results: All 1018 unit tests passed. (taking 12770.674 ms) ****
```