### PR TITLE
fix: Vec4 float/double operator% uses std::fmod instead of lossy SIMD approximation

### DIFF
--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -184,12 +184,25 @@ namespace pr::math
 	}
 	template <VectorType Vec> constexpr Vec pr_vectorcall operator % (typename vector_traits<Vec>::element_t lhs, Vec rhs) noexcept
 	{
+		// Scalar-left component-wise modulus. Floating-point types require std::fmod because
+		// the built-in % operator is not defined for float/double — they would be a compile
+		// error. Integer types use the built-in %.
 		using vt = vector_traits<Vec>;
 		Vec res = {};
-		if constexpr (vt::dimension > 0) vec(res).x = lhs % vec(rhs).x;
-		if constexpr (vt::dimension > 1) vec(res).y = lhs % vec(rhs).y;
-		if constexpr (vt::dimension > 2) vec(res).z = lhs % vec(rhs).z;
-		if constexpr (vt::dimension > 3) vec(res).w = lhs % vec(rhs).w;
+		if constexpr (std::is_floating_point_v<typename vt::element_t>)
+		{
+			if constexpr (vt::dimension > 0) vec(res).x = std::fmod(lhs, vec(rhs).x);
+			if constexpr (vt::dimension > 1) vec(res).y = std::fmod(lhs, vec(rhs).y);
+			if constexpr (vt::dimension > 2) vec(res).z = std::fmod(lhs, vec(rhs).z);
+			if constexpr (vt::dimension > 3) vec(res).w = std::fmod(lhs, vec(rhs).w);
+		}
+		else
+		{
+			if constexpr (vt::dimension > 0) vec(res).x = lhs % vec(rhs).x;
+			if constexpr (vt::dimension > 1) vec(res).y = lhs % vec(rhs).y;
+			if constexpr (vt::dimension > 2) vec(res).z = lhs % vec(rhs).z;
+			if constexpr (vt::dimension > 3) vec(res).w = lhs % vec(rhs).w;
+		}
 		return res;
 	}
 	template <VectorType Vec> constexpr auto pr_vectorcall operator <=> (Vec lhs, Vec rhs) noexcept

--- a/include/pr/math/tests/vector4_tests.h
+++ b/include/pr/math/tests/vector4_tests.h
@@ -130,16 +130,14 @@ namespace pr::math::tests
 			PR_EXPECT(Dot3(a, b) == T(-22)); // 3-component dot (ignores w)
 		}
 
-		// Verify that Vec4::operator% matches component-wise std::fmod / built-in % exactly.
-		// The SIMD approximation a − trunc(a/b)·b previously gave wrong results for large
-		// quotients on float and double. These tests reproduce and guard against that regression.
+		// Component-wise modulus for Vec%Vec, Vec%scalar, and scalar%Vec across all element types.
 		PRUnitTestMethod(Modulus, float, double, int32_t, int64_t)
 		{
 			using vec4_t = Vec4<T>;
 
 			if constexpr (std::is_floating_point_v<T>)
 			{
-				// Ordinary positive values: result in [0, divisor)
+				// Vec % Vec — ordinary positive values
 				{
 					auto lhs = vec4_t(T(7), T(10), T(3.5), T(0));
 					auto rhs = vec4_t(T(3), T( 4), T(1.5), T(2));
@@ -150,7 +148,7 @@ namespace pr::math::tests
 					PR_EXPECT(FEql(got.w, std::fmod(T(0),   T(2))));
 				}
 
-				// Signed dividend: fmod sign follows the dividend, not the divisor
+				// Vec % Vec — signed dividend: sign of result matches dividend sign
 				{
 					auto lhs = vec4_t(T(-7), T( 7), T(-7), T( 7));
 					auto rhs = vec4_t(T( 3), T( 3), T(-3), T(-3));
@@ -161,10 +159,7 @@ namespace pr::math::tests
 					PR_EXPECT(FEql(got.w, std::fmod(T( 7), T(-3))));
 				}
 
-				// Precision-exhausting large quotient: the regression case.
-				// 1e20 / 3 exceeds float's exact integer range (~16M), so trunc(a/b)
-				// is rounded before multiplication, and the SIMD approximation returned 0
-				// instead of 2. std::fmod carries the exact integer quotient internally.
+				// Vec % Vec — large quotient: |a/b| exceeds the mantissa's exact integer range
 				{
 					auto lhs = vec4_t(T(1e20), T(1e15), T(1e7), T(123456789));
 					auto rhs = vec4_t(T(3),    T(7),    T(11),  T(97));
@@ -175,38 +170,89 @@ namespace pr::math::tests
 					PR_EXPECT(FEql(got.w, std::fmod(T(123456789), T(97))));
 				}
 
-				// Exceptional inputs: IEEE 754 edge cases must match std::fmod per component
+				// Vec % scalar — exercises the Vec % element_t generic overload
+				{
+					auto lhs = vec4_t(T(7), T(-7), T(1e20), T(0));
+					auto got = lhs % T(3);
+					PR_EXPECT(FEql(got.x, std::fmod(T(7),    T(3))));
+					PR_EXPECT(FEql(got.y, std::fmod(T(-7),   T(3))));
+					PR_EXPECT(FEql(got.z, std::fmod(T(1e20), T(3))));
+					PR_EXPECT(FEql(got.w, std::fmod(T(0),    T(3))));
+				}
+
+				// scalar % Vec — exercises the element_t % Vec generic overload (compile fix)
+				{
+					auto rhs = vec4_t(T(3), T(-3), T(1e20), T(7));
+					auto got = T(10) % rhs;
+					PR_EXPECT(FEql(got.x, std::fmod(T(10), T(3))));
+					PR_EXPECT(FEql(got.y, std::fmod(T(10), T(-3))));
+					PR_EXPECT(FEql(got.z, std::fmod(T(10), T(1e20))));
+					PR_EXPECT(FEql(got.w, std::fmod(T(10), T(7))));
+				}
+
+				// IEEE 754 special cases — all three forms delegate to std::fmod per component
 				{
 					auto inf = std::numeric_limits<T>::infinity();
 					auto nan = std::numeric_limits<T>::quiet_NaN();
 					T three = T(3);
 
-					// infinity dividend → NaN (std::fmod(inf, finite) == NaN)
-					auto r_inf = Vec4<T>(inf, T(5), T(5), T(5)) % Vec4<T>(three, three, three, three);
-					PR_EXPECT(std::isnan(r_inf.x));
-					PR_EXPECT(!std::isnan(r_inf.y));
+					// infinity dividend → NaN
+					auto r_inf_lhs = Vec4<T>(inf, T(5), T(5), T(5)) % Vec4<T>(three, three, three, three);
+					PR_EXPECT(std::isnan(r_inf_lhs.x));
+					PR_EXPECT(!std::isnan(r_inf_lhs.y));
 
-					// zero divisor → NaN (std::fmod(finite, 0) == NaN)
+					// finite % infinity → finite (remainder equals dividend)
+					auto r_inf_rhs = Vec4<T>(T(5), inf, T(5), T(5)) % Vec4<T>(inf, three, three, three);
+					PR_EXPECT(FEql(r_inf_rhs.x, std::fmod(T(5), inf)));
+					PR_EXPECT(std::isnan(r_inf_rhs.y));
+
+					// zero divisor → NaN
 					auto r_zero = Vec4<T>(T(5), T(5), T(5), T(5)) % Vec4<T>(T(0), three, three, three);
 					PR_EXPECT(std::isnan(r_zero.x));
 					PR_EXPECT(!std::isnan(r_zero.y));
 
-					// NaN propagates from either operand
+					// NaN propagates
 					auto r_nan = Vec4<T>(nan, T(5), T(5), T(5)) % Vec4<T>(three, three, three, three);
 					PR_EXPECT(std::isnan(r_nan.x));
 					PR_EXPECT(!std::isnan(r_nan.y));
+
+					// signed-zero dividend: sign of zero is preserved by fmod
+					T neg_zero = -T(0);
+					auto r_neg_zero = Vec4<T>(neg_zero, T(0), T(5), T(5)) % Vec4<T>(three, three, three, three);
+					PR_EXPECT(std::signbit(r_neg_zero.x));   // -0 % 3 == -0
+					PR_EXPECT(!std::signbit(r_neg_zero.y));  // +0 % 3 == +0
 				}
 			}
 			else
 			{
-				// Integer modulus must match built-in % exactly (truncation toward zero)
-				auto a = vec4_t(T(10), T(-10), T(10), T(-10));
-				auto b = vec4_t(T( 3), T(  3), T(-3), T( -3));
-				auto got = a % b;
-				PR_EXPECT(got.x == T(10) % T( 3));   //  1
-				PR_EXPECT(got.y == T(-10) % T( 3));  // -1
-				PR_EXPECT(got.z == T(10) % T(-3));   //  1
-				PR_EXPECT(got.w == T(-10) % T(-3));  // -1
+				// Vec % Vec — integer modulus truncates toward zero (C++ standard)
+				{
+					auto a = vec4_t(T(10), T(-10), T(10), T(-10));
+					auto b = vec4_t(T( 3), T(  3), T(-3), T( -3));
+					auto got = a % b;
+					PR_EXPECT(got.x == T(10) % T( 3));   //  1
+					PR_EXPECT(got.y == T(-10) % T( 3));  // -1
+					PR_EXPECT(got.z == T(10) % T(-3));   //  1
+					PR_EXPECT(got.w == T(-10) % T(-3));  // -1
+				}
+
+				// Vec % scalar
+				{
+					auto got = vec4_t(T(10), T(-10), T(10), T(-10)) % T(3);
+					PR_EXPECT(got.x == T( 10) % T(3));
+					PR_EXPECT(got.y == T(-10) % T(3));
+					PR_EXPECT(got.z == T( 10) % T(3));
+					PR_EXPECT(got.w == T(-10) % T(3));
+				}
+
+				// scalar % Vec
+				{
+					auto got = T(10) % vec4_t(T(3), T(-3), T(7), T(-7));
+					PR_EXPECT(got.x == T(10) % T( 3));
+					PR_EXPECT(got.y == T(10) % T(-3));
+					PR_EXPECT(got.z == T(10) % T( 7));
+					PR_EXPECT(got.w == T(10) % T(-7));
+				}
 			}
 		}
 	};

--- a/include/pr/math/tests/vector4_tests.h
+++ b/include/pr/math/tests/vector4_tests.h
@@ -129,6 +129,86 @@ namespace pr::math::tests
 			PR_EXPECT(Dot(a, b) == T(-46));  // Full 4-component dot
 			PR_EXPECT(Dot3(a, b) == T(-22)); // 3-component dot (ignores w)
 		}
+
+		// Verify that Vec4::operator% matches component-wise std::fmod / built-in % exactly.
+		// The SIMD approximation a − trunc(a/b)·b previously gave wrong results for large
+		// quotients on float and double. These tests reproduce and guard against that regression.
+		PRUnitTestMethod(Modulus, float, double, int32_t, int64_t)
+		{
+			using vec4_t = Vec4<T>;
+
+			if constexpr (std::is_floating_point_v<T>)
+			{
+				// Ordinary positive values: result in [0, divisor)
+				{
+					auto lhs = vec4_t(T(7), T(10), T(3.5), T(0));
+					auto rhs = vec4_t(T(3), T( 4), T(1.5), T(2));
+					auto got = lhs % rhs;
+					PR_EXPECT(FEql(got.x, std::fmod(T(7),   T(3))));
+					PR_EXPECT(FEql(got.y, std::fmod(T(10),  T(4))));
+					PR_EXPECT(FEql(got.z, std::fmod(T(3.5), T(1.5))));
+					PR_EXPECT(FEql(got.w, std::fmod(T(0),   T(2))));
+				}
+
+				// Signed dividend: fmod sign follows the dividend, not the divisor
+				{
+					auto lhs = vec4_t(T(-7), T( 7), T(-7), T( 7));
+					auto rhs = vec4_t(T( 3), T( 3), T(-3), T(-3));
+					auto got = lhs % rhs;
+					PR_EXPECT(FEql(got.x, std::fmod(T(-7), T( 3))));
+					PR_EXPECT(FEql(got.y, std::fmod(T( 7), T( 3))));
+					PR_EXPECT(FEql(got.z, std::fmod(T(-7), T(-3))));
+					PR_EXPECT(FEql(got.w, std::fmod(T( 7), T(-3))));
+				}
+
+				// Precision-exhausting large quotient: the regression case.
+				// 1e20 / 3 exceeds float's exact integer range (~16M), so trunc(a/b)
+				// is rounded before multiplication, and the SIMD approximation returned 0
+				// instead of 2. std::fmod carries the exact integer quotient internally.
+				{
+					auto lhs = vec4_t(T(1e20), T(1e15), T(1e7), T(123456789));
+					auto rhs = vec4_t(T(3),    T(7),    T(11),  T(97));
+					auto got = lhs % rhs;
+					PR_EXPECT(FEql(got.x, std::fmod(T(1e20),      T(3))));
+					PR_EXPECT(FEql(got.y, std::fmod(T(1e15),      T(7))));
+					PR_EXPECT(FEql(got.z, std::fmod(T(1e7),       T(11))));
+					PR_EXPECT(FEql(got.w, std::fmod(T(123456789), T(97))));
+				}
+
+				// Exceptional inputs: IEEE 754 edge cases must match std::fmod per component
+				{
+					auto inf = std::numeric_limits<T>::infinity();
+					auto nan = std::numeric_limits<T>::quiet_NaN();
+					T three = T(3);
+
+					// infinity dividend → NaN (std::fmod(inf, finite) == NaN)
+					auto r_inf = Vec4<T>(inf, T(5), T(5), T(5)) % Vec4<T>(three, three, three, three);
+					PR_EXPECT(std::isnan(r_inf.x));
+					PR_EXPECT(!std::isnan(r_inf.y));
+
+					// zero divisor → NaN (std::fmod(finite, 0) == NaN)
+					auto r_zero = Vec4<T>(T(5), T(5), T(5), T(5)) % Vec4<T>(T(0), three, three, three);
+					PR_EXPECT(std::isnan(r_zero.x));
+					PR_EXPECT(!std::isnan(r_zero.y));
+
+					// NaN propagates from either operand
+					auto r_nan = Vec4<T>(nan, T(5), T(5), T(5)) % Vec4<T>(three, three, three, three);
+					PR_EXPECT(std::isnan(r_nan.x));
+					PR_EXPECT(!std::isnan(r_nan.y));
+				}
+			}
+			else
+			{
+				// Integer modulus must match built-in % exactly (truncation toward zero)
+				auto a = vec4_t(T(10), T(-10), T(10), T(-10));
+				auto b = vec4_t(T( 3), T(  3), T(-3), T( -3));
+				auto got = a % b;
+				PR_EXPECT(got.x == T(10) % T( 3));   //  1
+				PR_EXPECT(got.y == T(-10) % T( 3));  // -1
+				PR_EXPECT(got.z == T(10) % T(-3));   //  1
+				PR_EXPECT(got.w == T(-10) % T(-3));  // -1
+			}
+		}
 	};
 }
 #endif

--- a/include/pr/math/types/vector4.h
+++ b/include/pr/math/types/vector4.h
@@ -383,34 +383,15 @@ namespace pr::math
 		}
 		friend constexpr Vec4 pr_vectorcall operator % (Vec4 lhs, Vec4 rhs) noexcept
 		{
-			// Don't check for divide by zero by default. For floats +inf/-inf are valid results
-			if consteval
-			{
-				return math::operator%<Vec4>(lhs, rhs);
-			}
-			else
-			{
-				if constexpr (IntrinsicF)
-				{
-					auto div = _mm_div_ps(lhs.vec, rhs.vec);                                // a / b
-					auto trunc = _mm_round_ps(div, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC); // trunc(a / b)
-					auto prod = _mm_mul_ps(trunc, rhs.vec);                                 // trunc(a / b) * b
-					auto rem = _mm_sub_ps(lhs.vec, prod);                                   // a - b * trunc(a / b) => fmod
-					return Vec4{ rem };
-				}
-				else if constexpr (IntrinsicD)
-				{
-					auto div = _mm256_div_pd(lhs.vec, rhs.vec);                                // a / b
-					auto trunc = _mm256_round_pd(div, _MM_FROUND_TO_ZERO | _MM_FROUND_NO_EXC); // trunc(a / b)
-					auto prod = _mm256_mul_pd(trunc, rhs.vec);                                 // trunc(a / b) * b
-					auto rem = _mm256_sub_pd(lhs.vec, prod);                                   // a - b * trunc(a / b) => fmod
-					return Vec4{ rem };
-				}
-				else
-				{
-					return math::operator%<Vec4>(lhs, rhs);
-				}
-			}
+			// Component-wise modulus: std::fmod semantics for floating-point types, built-in %
+			// for integers. There is no correct SIMD fast path for floating-point modulus:
+			// the approximation a − trunc(a/b)·b gives the wrong answer when |a/b| exceeds
+			// the mantissa's integer representable range, because the float-precision quotient
+			// is rounded before truncation. For example, Vec4<float>(1e20f) % 3 yields 0
+			// instead of the correct 2. std::fmod avoids this by carrying the exact integer
+			// quotient internally. Both float and integer cases are handled correctly by the
+			// generic component-wise path.
+			return math::operator%<Vec4>(lhs, rhs);
 		}
 		#pragma endregion
 

--- a/include/pr/math/types/vector4.h
+++ b/include/pr/math/types/vector4.h
@@ -383,14 +383,10 @@ namespace pr::math
 		}
 		friend constexpr Vec4 pr_vectorcall operator % (Vec4 lhs, Vec4 rhs) noexcept
 		{
-			// Component-wise modulus: std::fmod semantics for floating-point types, built-in %
-			// for integers. There is no correct SIMD fast path for floating-point modulus:
-			// the approximation a − trunc(a/b)·b gives the wrong answer when |a/b| exceeds
-			// the mantissa's integer representable range, because the float-precision quotient
-			// is rounded before truncation. For example, Vec4<float>(1e20f) % 3 yields 0
-			// instead of the correct 2. std::fmod avoids this by carrying the exact integer
-			// quotient internally. Both float and integer cases are handled correctly by the
-			// generic component-wise path.
+			// Component-wise modulus. Float/double use std::fmod semantics (sign follows the
+			// dividend; finite%infinity==finite; 0%0==NaN). Integers use built-in % (truncation
+			// toward zero). No SIMD fast path exists for floating-point: std::fmod requires an
+			// exact integer quotient that cannot be represented in float for large |a/b|.
 			return math::operator%<Vec4>(lhs, rhs);
 		}
 		#pragma endregion


### PR DESCRIPTION
## Problem

`Vec4<float>::operator%` and `Vec4<double>::operator%` used an SIMD fast path that implements fmod as:

```
a - trunc(a / b) * b
```

This is **wrong** when `|a/b|` exceeds the type's mantissa precision. For `float`, the mantissa holds ~16M exactly-representable integers. When the true quotient is larger, `_mm_div_ps` returns a rounded value, `_mm_round_ps` truncates the already-wrong value, and the multiply produces an incorrect remainder.

**Reproduction:**
```cpp
Vec4<float>(1e20f) % Vec4<float>(3.0f)  // old → {0,0,0,0}  wrong
                                         // new → {2,2,2,2}  correct
std::fmod(1e20f, 3.0f)                  // → 2.0f  (reference)
```

The `constexpr`/generic path was already correct (it delegates to `std::fmod`), but the SIMD runtime path bypassed it.

## Fix

### `include/pr/math/types/vector4.h`
Remove the `IntrinsicF` and `IntrinsicD` branches from `Vec4::operator%`. Delegate all element types to `math::operator%<Vec4>`, which already uses `std::fmod` component-wise for floats and built-in `%` for integers. There is no correct all-SIMD implementation of IEEE 754 fmod.

### `include/pr/math/core/functions.h`
Fix a latent compile-error bug in the scalar-left `operator%(element_t, Vec)` generic template. The original code contained `float % float` (built-in `%` is not defined for floating-point types). Added `if constexpr` dispatch to use `std::fmod` for float/double, preserving `%` for integer types.

### `include/pr/math/tests/vector4_tests.h`
Add `Modulus` unit test for all four element types (float, double, int32_t, int64_t), covering:
- Ordinary positive values
- Signed dividend (sign follows dividend per fmod/C++ semantics)
- Precision-exhausting large quotient (`1e20f % 3 == 2`) — the regression case
- IEEE 754 exceptional inputs: infinity dividend, zero divisor, NaN propagation
- Integer truncation-toward-zero

## Validation

Compiled with VS2026/v145 Debug x64 (`PR_MATHS_USE_INTRINSICS=1`). Standalone test program output:
```
1e20f % 3.0f = 2.0 (expected 2.0) -- PASS
1e20  % 3.0  = 1.0 (expected 1.0) -- PASS
-7.0f % 3.0f = -1.0 (expected -1.0) -- PASS
10 % 3 = 1 (expected 1) -- PASS
```

The full unittests project build stalls on a pre-existing infrastructure issue (missing `WinPixEventRuntime.dll` in the worktree packages folder, unrelated to these changes). The compilation phase of the math tests completed without errors.