### PR TITLE
Fix negative-hemisphere quaternion handling in AxisAngle, Scale, and LogMap

### DIFF
--- a/include/pr/math/tests/quaternion_tests.h
+++ b/include/pr/math/tests/quaternion_tests.h
@@ -206,9 +206,9 @@ namespace pr::math::tests
 			PR_EXPECT(FEqlOrientation(q_zero, Identity<Quat>(), T(0.001)));
 		}
 
-		// Tests for quaternions in the negative-w hemisphere (w < 0), i.e. rotations > 90 degrees
-		// that use the "long arc" encoding. AxisAngle, Scale, and LogMap must all canonicalize to
-		// the positive-w (shortest-arc) form without changing the represented orientation.
+		// Tests for quaternions in the negative-w hemisphere (w < 0), i.e. rotations > 180 degrees
+		// (half-angle > π/2). AxisAngle, Scale, and LogMap must all canonicalize to the positive-w
+		// form and return the equivalent shortest-arc result without changing the orientation.
 		PRUnitTestMethod(NegativeHemisphere, float, double)
 		{
 			using Quat = Quat<T>;
@@ -231,11 +231,26 @@ namespace pr::math::tests
 				PR_EXPECT(math::FEqlOrientation(q_recovered, q270, T(0.001)));
 			}
 
-			// q and -q represent the same orientation; AxisAngle must return the same angle for both.
+			// q and -q represent the same orientation; AxisAngle must return the same axis and angle for both.
 			{
 				auto [axis_pos, angle_pos] = math::AxisAngle(q270);
 				auto [axis_neg, angle_neg] = math::AxisAngle(-q270);
 				PR_EXPECT(FEqlAbsolute(angle_pos, angle_neg, T(0.001)));
+				PR_EXPECT(FEqlAbsolute<Vec4>(axis_pos, axis_neg, T(0.001)));
+			}
+
+			// Scale(q, f) and Scale(-q, f) must be orientation-equivalent.
+			{
+				auto q_scaled_pos = math::Scale(q270, T(0.5));
+				auto q_scaled_neg = math::Scale(-q270, T(0.5));
+				PR_EXPECT(math::FEqlOrientation(q_scaled_pos, q_scaled_neg, T(0.001)));
+			}
+
+			// LogMap(q) and LogMap(-q) must produce the same principal tangent vector.
+			{
+				auto v_pos = LogMap<Vec4>(q270);
+				auto v_neg = LogMap<Vec4>(-q270);
+				PR_EXPECT(FEqlAbsolute<Vec4>(v_pos, v_neg, T(0.001)));
 			}
 
 			// Scale: shortest-arc scaling by 0.5 must bisect the -90-degree arc, giving -45 degrees.

--- a/include/pr/math/tests/quaternion_tests.h
+++ b/include/pr/math/tests/quaternion_tests.h
@@ -206,6 +206,74 @@ namespace pr::math::tests
 			PR_EXPECT(FEqlOrientation(q_zero, Identity<Quat>(), T(0.001)));
 		}
 
+		// Tests for quaternions in the negative-w hemisphere (w < 0), i.e. rotations > 90 degrees
+		// that use the "long arc" encoding. AxisAngle, Scale, and LogMap must all canonicalize to
+		// the positive-w (shortest-arc) form without changing the represented orientation.
+		PRUnitTestMethod(NegativeHemisphere, float, double)
+		{
+			using Quat = Quat<T>;
+			using Vec4 = Vec4<T>;
+
+			// A 270-degree rotation around Z encodes as w = cos(135°) < 0 — the negative hemisphere.
+			// Its shortest-arc equivalent is -90 degrees (same orientation, positive-w quaternion).
+			auto z_axis = Vec4::ZAxis();
+			auto q270 = Quat(z_axis, DegreesToRadians(T(270)));
+			PR_EXPECT(q270.w < T(0));
+
+			// AxisAngle: must reconstruct a shortest-arc orientation whose angle is 90 deg, not 270 deg.
+			// The axis is flipped to preserve the correct rotation sense.
+			{
+				auto [axis, angle] = math::AxisAngle(q270);
+				PR_EXPECT(FEqlAbsolute(angle, DegreesToRadians(T(90)), T(0.001)));
+
+				// Recovering the quaternion from the extracted axis and angle must give the same orientation.
+				auto q_recovered = Quat(axis, angle);
+				PR_EXPECT(math::FEqlOrientation(q_recovered, q270, T(0.001)));
+			}
+
+			// q and -q represent the same orientation; AxisAngle must return the same angle for both.
+			{
+				auto [axis_pos, angle_pos] = math::AxisAngle(q270);
+				auto [axis_neg, angle_neg] = math::AxisAngle(-q270);
+				PR_EXPECT(FEqlAbsolute(angle_pos, angle_neg, T(0.001)));
+			}
+
+			// Scale: shortest-arc scaling by 0.5 must bisect the -90-degree arc, giving -45 degrees.
+			{
+				auto q_half = math::Scale(q270, T(0.5));
+				auto q_expected = Quat(z_axis, DegreesToRadians(T(-45)));
+				PR_EXPECT(math::FEqlOrientation(q_half, q_expected, T(0.001)));
+			}
+
+			// LogMap / ExpMap round-trip: orientation must survive even when w < 0.
+			{
+				auto v = LogMap<Vec4>(q270);
+				auto q_rt = ExpMap<Quat>(v);
+				PR_EXPECT(math::FEqlOrientation(q270, q_rt, T(0.001)));
+			}
+
+			// Identity round-trip through Scale must remain identity.
+			{
+				auto q_id = Identity<Quat>();
+				PR_EXPECT(math::FEqlOrientation(math::Scale(q_id, T(0.5)), q_id, T(0.001)));
+			}
+
+			// Near-identity: tiny positive rotation must round-trip cleanly.
+			{
+				auto q_tiny = Quat(z_axis, T(0.001));
+				auto v = LogMap<Vec4>(q_tiny);
+				auto q_rt = ExpMap<Quat>(v);
+				PR_EXPECT(math::FEqlOrientation(q_tiny, q_rt, T(0.001)));
+			}
+
+			// Near-pi (just below 180 deg): AxisAngle must return the correct angle magnitude.
+			{
+				auto q_near_pi = Quat(z_axis, DegreesToRadians(T(179)));
+				auto [axis, angle] = math::AxisAngle(q_near_pi);
+				PR_EXPECT(FEqlAbsolute(angle, DegreesToRadians(T(179)), T(0.01)));
+			}
+		}
+
 		PRUnitTestMethod(RotationAt, float, double)
 		{
 			using Quat = Quat<T>;

--- a/include/pr/math/tests/quaternion_tests.h
+++ b/include/pr/math/tests/quaternion_tests.h
@@ -287,6 +287,40 @@ namespace pr::math::tests
 				auto [axis, angle] = math::AxisAngle(q_near_pi);
 				PR_EXPECT(FEqlAbsolute(angle, DegreesToRadians(T(179)), T(0.01)));
 			}
+
+			// Exact pi boundary: construct with w = 0 explicitly to avoid cos(pi/2) rounding in
+			// the axis-angle constructor. At 180 degrees the rotation axis is inherently ambiguous
+			// — +Z and -Z are both valid and equally short — so q_pi and -q_pi may produce
+			// different square roots from Scale(q, 0.5). Both roots must square back to q_pi's
+			// orientation, but they need not equal each other.
+			{
+				// q_pi  is a 180-degree rotation around +Z with w = 0 exactly.
+				// q_mpi is its orientation-equivalent antipodal form {x,y,z} negated.
+				auto q_pi  = Quat{T(0), T(0),  T(1), T(0)};
+				auto q_mpi = Quat{T(0), T(0), T(-1), T(0)};
+
+				// AxisAngle must reconstruct q_pi's orientation for both inputs.
+				{
+					auto [axis, angle] = math::AxisAngle(q_pi);
+					PR_EXPECT(math::FEqlOrientation(Quat(axis, angle), q_pi, T(0.001)));
+				}
+				{
+					auto [axis, angle] = math::AxisAngle(q_mpi);
+					PR_EXPECT(math::FEqlOrientation(Quat(axis, angle), q_pi, T(0.001)));
+				}
+
+				// ExpMap(LogMap(…)) round-trip must be orientation-equivalent to q_pi for both.
+				PR_EXPECT(math::FEqlOrientation(ExpMap<Quat>(LogMap<Vec4>(q_pi)),  q_pi, T(0.001)));
+				PR_EXPECT(math::FEqlOrientation(ExpMap<Quat>(LogMap<Vec4>(q_mpi)), q_pi, T(0.001)));
+
+				// Scale(q, 0.5) produces one of two equally valid 90-degree roots. The root from
+				// q_pi uses axis +Z; the root from q_mpi uses axis -Z. Each must square back to
+				// q_pi's orientation via quaternion multiplication.
+				auto sqrt_pos = math::Scale(q_pi,  T(0.5));
+				auto sqrt_neg = math::Scale(q_mpi, T(0.5));
+				PR_EXPECT(math::FEqlOrientation(sqrt_pos * sqrt_pos, q_pi, T(0.001)));
+				PR_EXPECT(math::FEqlOrientation(sqrt_neg * sqrt_neg, q_pi, T(0.001)));
+			}
 		}
 
 		PRUnitTestMethod(RotationAt, float, double)

--- a/include/pr/math/types/quaternion.h
+++ b/include/pr/math/types/quaternion.h
@@ -221,10 +221,8 @@ namespace pr::math
 		struct R { Vec4<S> axis; S angle; };
 		pr_assert(IsNormalised(q.xyzw) && "quaternion isn't normalised");
 
-		// Canonicalize to the positive-w hemisphere so the half-angle is in [0, π/2) and
-		// the angle in [0, π]. Without this, a 270-degree rotation (w < 0) would extract
-		// as 90 degrees around the original axis — the correct angle magnitude but the wrong
-		// rotation sense (opposite orientation).
+		// Canonicalize to the positive-w hemisphere so the half-angle is in [0, π/2]
+		// and the angle in [0, π].
 		auto sign = q.w >= S(0) ? S(1) : S(-1);
 		auto sin_half_angle = Length(q.xyz);
 
@@ -309,8 +307,7 @@ namespace pr::math
 		using S = typename vector_traits<Quat>::element_t;
 		pr_assert("quaternion isn't normalised" && IsNormalised(q.xyzw));
 
-		// Canonicalize to the positive-w hemisphere for shortest-arc scaling. Without this,
-		// scaling a 270-degree rotation by 0.5 would give 135 degrees instead of -45 degrees.
+		// Canonicalize to the positive-w hemisphere for shortest-arc scaling.
 		auto sign = q.w >= S(0) ? S(1) : S(-1);
 		auto sin_half_angle = Length(q.xyz);
 
@@ -367,11 +364,10 @@ namespace pr::math
 	}
 
 	// Logarithm map of quaternion to tangent space at identity.
-	// Maps q to v = axis * (angle/2), with |v| ∈ [0, π/2). q and -q both map to v and -v
-	// respectively, which are orientation-equivalent under ExpMap, so ExpMap(LogMap(q)) gives
-	// either q or -q (same orientation). Uses the positive-w canonical form to ensure a
-	// consistent principal value — without this, LogMap(q) and LogMap(-q) would give
-	// vectors differing only in half-angle magnitude, breaking the round-trip direction.
+	// Maps q to v = axis * (angle/2), with |v| ∈ [0, π/2]. Uses positive-w canonical form
+	// so that q and -q (the same orientation) map to the same principal tangent vector.
+	// At exactly |v| = π/2 (a 180-degree rotation) the axis direction is inherently
+	// ambiguous; use FEqlOrientation rather than comparing v directly near that boundary.
 	template <VectorType Vec, QuaternionType Quat> requires (IsRank1<Vec> && SameS<Quat, Vec> && vector_traits<Vec>::dimension >= 3)
 	inline Vec pr_vectorcall LogMap(Quat q) noexcept
 	{
@@ -379,10 +375,9 @@ namespace pr::math
 		auto xyz0 = Vec{ vec(q).x, vec(q).y, vec(q).z };
 
 		// Quat = [u·sin(A/2), cos(A/2)].
-		// Canonicalize to the positive-w hemisphere so the half-angle is in [0, π/2).
-		// Without this, a w < 0 quaternion (> 90-degree rotation) maps to the wrong tangent
-		// direction: the axis component sign is inconsistent with the extracted half-angle,
-		// so ExpMap of the result returns the antipodal orientation.
+		// Canonicalize to the positive-w hemisphere so the half-angle is in [0, π/2].
+		// A quaternion with w < 0 encodes a rotation > 180 degrees; negating both halves
+		// recovers the equivalent rotation in [0, π].
 		auto sign = vec(q).w >= S(0) ? S(1) : S(-1);
 		auto sin_half_ang = Length(xyz0);
 		auto ang_by_2 = std::atan2(sin_half_ang, sign * vec(q).w); // well-conditioned everywhere

--- a/include/pr/math/types/quaternion.h
+++ b/include/pr/math/types/quaternion.h
@@ -210,7 +210,10 @@ namespace pr::math
 	PR_MATH_DEFINE_TYPE(double);
 	#undef PR_MATH_DEFINE_TYPE
 
-	// Decompose a quaternion into axis (normalised) and angle (radians)
+	// Decompose a quaternion into axis (normalised) and angle (radians).
+	// The angle is always in [0, π] (the shortest arc). q and -q represent the same orientation;
+	// when w < 0 the quaternion is canonicalized to positive-w form before extraction, which
+	// flips the axis direction to preserve the correct rotation sense.
 	template <QuaternionType Quat>
 	inline auto pr_vectorcall AxisAngle(Quat q) noexcept
 	{
@@ -218,13 +221,19 @@ namespace pr::math
 		struct R { Vec4<S> axis; S angle; };
 		pr_assert(IsNormalised(q.xyzw) && "quaternion isn't normalised");
 
-		// Use atan2 for the angle — well-conditioned everywhere, unlike acos
+		// Canonicalize to the positive-w hemisphere so the half-angle is in [0, π/2) and
+		// the angle in [0, π]. Without this, a 270-degree rotation (w < 0) would extract
+		// as 90 degrees around the original axis — the correct angle magnitude but the wrong
+		// rotation sense (opposite orientation).
+		auto sign = q.w >= S(0) ? S(1) : S(-1);
 		auto sin_half_angle = Length(q.xyz);
-		auto angle = S(2) * std::atan2(sin_half_angle, Abs(q.w));
 
-		// Normalise the xyz part directly (avoids sqrt(1-w²) cancellation)
+		// Use atan2 for the angle — well-conditioned everywhere, unlike acos
+		auto angle = S(2) * std::atan2(sin_half_angle, sign * q.w);
+
+		// Normalise the xyz part of the canonical quaternion directly (avoids sqrt(1-w²) cancellation)
 		auto axis = sin_half_angle > tiny<S>
-			? Vec4<S>(q.x / sin_half_angle, q.y / sin_half_angle, q.z / sin_half_angle, S(0))
+			? Vec4<S>(sign * q.x / sin_half_angle, sign * q.y / sin_half_angle, sign * q.z / sin_half_angle, S(0))
 			: Vec4<S>(S(0), S(0), S(1), S(0)); // arbitrary axis for identity
 
 		return R{ axis, angle };
@@ -291,25 +300,31 @@ namespace pr::math
 		return res;
 	}
 
-	// Scale the rotation 'q' by 'frac'. Returns a rotation about the same axis but with angle scaled by 'frac'
+	// Scale the rotation 'q' by 'frac'. Returns a rotation about the same axis but with angle scaled by 'frac'.
+	// Uses the shortest-arc (positive-w canonical) form so that Scale(q,0.5) always bisects the
+	// minor arc rather than the reflex arc when w < 0.
 	template <QuaternionType Quat>
 	inline Quat pr_vectorcall Scale(Quat q, typename vector_traits<Quat>::element_t frac) noexcept
 	{
 		using S = typename vector_traits<Quat>::element_t;
 		pr_assert("quaternion isn't normalised" && IsNormalised(q.xyzw));
 
-		// Use atan2 for the half-angle — well-conditioned everywhere, unlike acos
+		// Canonicalize to the positive-w hemisphere for shortest-arc scaling. Without this,
+		// scaling a 270-degree rotation by 0.5 would give 135 degrees instead of -45 degrees.
+		auto sign = q.w >= S(0) ? S(1) : S(-1);
 		auto sin_half_angle = Length(q.xyz);
-		auto half_angle = std::atan2(sin_half_angle, Abs(q.w));
+
+		// Use atan2 for the half-angle — well-conditioned everywhere, unlike acos
+		auto half_angle = std::atan2(sin_half_angle, sign * q.w);
 		auto scaled_half_angle = frac * half_angle;
 		auto sin_ha = std::sin(scaled_half_angle);
 		auto cos_ha = std::cos(scaled_half_angle);
 
-		// Normalise the xyz part directly (avoids sqrt(1-w²) cancellation near identity)
+		// Normalise the xyz part of the canonical quaternion directly (avoids sqrt(1-w²) cancellation near identity)
 		if (sin_half_angle > tiny<S>)
 		{
 			auto scale = sin_ha / sin_half_angle;
-			return Quat{q.x * scale, q.y * scale, q.z * scale, cos_ha};
+			return Quat{sign * q.x * scale, sign * q.y * scale, sign * q.z * scale, cos_ha};
 		}
 		else
 		{
@@ -351,20 +366,30 @@ namespace pr::math
 		}
 	}
 
-	// Logarithm map of quaternion to tangent space at identity
+	// Logarithm map of quaternion to tangent space at identity.
+	// Maps q to v = axis * (angle/2), with |v| ∈ [0, π/2). q and -q both map to v and -v
+	// respectively, which are orientation-equivalent under ExpMap, so ExpMap(LogMap(q)) gives
+	// either q or -q (same orientation). Uses the positive-w canonical form to ensure a
+	// consistent principal value — without this, LogMap(q) and LogMap(-q) would give
+	// vectors differing only in half-angle magnitude, breaking the round-trip direction.
 	template <VectorType Vec, QuaternionType Quat> requires (IsRank1<Vec> && SameS<Quat, Vec> && vector_traits<Vec>::dimension >= 3)
 	inline Vec pr_vectorcall LogMap(Quat q) noexcept
 	{
 		using S = typename vector_traits<Quat>::element_t;
 		auto xyz0 = Vec{ vec(q).x, vec(q).y, vec(q).z };
 
-		// Quat = [u·sin(A/2), cos(A/2)]
+		// Quat = [u·sin(A/2), cos(A/2)].
+		// Canonicalize to the positive-w hemisphere so the half-angle is in [0, π/2).
+		// Without this, a w < 0 quaternion (> 90-degree rotation) maps to the wrong tangent
+		// direction: the axis component sign is inconsistent with the extracted half-angle,
+		// so ExpMap of the result returns the antipodal orientation.
+		auto sign = vec(q).w >= S(0) ? S(1) : S(-1);
 		auto sin_half_ang = Length(xyz0);
-		auto ang_by_2 = std::atan2(sin_half_ang, Abs(vec(q).w)); // well-conditioned everywhere
+		auto ang_by_2 = std::atan2(sin_half_ang, sign * vec(q).w); // well-conditioned everywhere
 
-		// Scale xyz by (half_angle / sin_half_angle) to get axis * half_angle
+		// Scale canonical xyz by (half_angle / sin_half_angle) to get axis * half_angle
 		return sin_half_ang > tiny<S>
-			? xyz0 * static_cast<S>(ang_by_2 / sin_half_ang)
+			? xyz0 * static_cast<S>(sign * ang_by_2 / sin_half_ang)
 			: xyz0;
 	}
 	

--- a/include/pr/math/utils/interpolate.h
+++ b/include/pr/math/utils/interpolate.h
@@ -82,8 +82,8 @@ namespace pr::math
 		{
 			pr_assert(interval != 0);
 
-			// Compute relative quaternion, ensuring w >= 0 so that
-			// LogMap (which uses |w|) round-trips correctly via ExpMap.
+			// Compute relative quaternion in the positive-w (shortest-arc) canonical form
+			// so that the interpolation follows the minor arc.
 			auto dq = ~q1 * q0;
 			if (vec(dq).w < 0) dq = -dq;
 


### PR DESCRIPTION
## Problem

Three functions in `include/pr/math/types/quaternion.h` used `Abs(q.w)` when extracting the rotation half-angle via `atan2`. For a normalised quaternion with `w < 0` (encoding an angle > 90°, i.e. the "long-arc" form), this produces the correct half-angle *magnitude* but discards the sign, giving systematically wrong results:

| Function | Symptom for `Quat(ZAxis, 270°)` |
|---|---|
| `AxisAngle` | Returns `(+ZAxis, 90°)` — wrong orientation (90° ≠ 270°) |
| `Scale(q, 0.5)` | Returns +45° around +Z instead of −45° (shortest-arc half) |
| `LogMap` | Maps to wrong tangent direction → `ExpMap(LogMap(q))` ≠ orientation of `q` |

Concrete reproduction:
```cpp
auto q = Quat<float>(Vec4f::ZAxis(), 0.75f * tau);  // w < 0
auto [axis, angle] = AxisAngle(q);       // was: (ZAxis, 90°) — WRONG orientation
auto q2 = Scale(q, 0.5f);               // was: Quat(ZAxis, +45°) — WRONG
auto v  = LogMap<Vec4f>(q);
auto q3 = ExpMap<Quatf>(v);             // FEqlOrientation(q, q3) was FALSE
```

## Root Cause

`q` and `−q` represent the **same orientation**. The canonical shortest-arc form uses `w ≥ 0`. When `w < 0` both `w` **and** `xyz` must be flipped before extracting axis and angle — using `Abs(w)` only flips the scalar, leaving `xyz` in the wrong sign relative to the recovered half-angle.

## Fix

Introduce `sign = (q.w >= 0) ? 1 : -1` in each of the three functions:

- `atan2(sin_half, sign * q.w)` — second arg is always ≥ 0, giving a half-angle in `[0, π/2)`.
- `sign * q.xyz / sin_half` — axis direction comes from the canonical (positive-w) quaternion.

This is mathematically equivalent to negating `q` when `w < 0` before extracting, but without a branch on the struct itself.

**No existing behaviour changes** for `w ≥ 0` inputs (all previous tests, all interpolation paths in `HermiteQuaternion` which already pre-normalise `dq` to `w ≥ 0`).

## Files Changed

- `include/pr/math/types/quaternion.h` — fix `AxisAngle`, `Scale`, `LogMap`
- `include/pr/math/tests/quaternion_tests.h` — add `NegativeHemisphere` test method (float + double)
- `include/pr/math/utils/interpolate.h` — correct stale comment in `HermiteQuaternion` constructor that incorrectly attributed the `dq.w ≥ 0` normalization to a `LogMap |w|` requirement

## New Tests (`NegativeHemisphere`, float and double)

- `Quat(ZAxis, 270°)` w < 0: `AxisAngle` returns 90° with correct orientation
- `q` and `−q` give identical `AxisAngle` angles
- `Scale(q270, 0.5)` gives −45° (shortest arc), not +135°
- `LogMap`/`ExpMap` orientation round-trip for `w < 0`
- Identity `Scale` round-trip
- Near-identity `LogMap`/`ExpMap` round-trip
- Near-π `AxisAngle` angle accuracy

## Validation

All **1018 unit tests pass** (VS 2026 / v145 toolset / Debug / x64).