### PR TITLE
fix: correct generic vector constructors (Rank1VecSN concept + iterator-based range access)

### DIFF
--- a/include/pr/math/core/traits.h
+++ b/include/pr/math/core/traits.h
@@ -50,6 +50,15 @@ namespace pr::math
 	template <typename T>
 	concept IsRank2 = VectorType<T> && VectorType<typename vector_traits<T>::component_t> && !VectorType<typename vector_traits<typename vector_traits<T>::component_t>::component_t>;
 
+	// Rank-1 vector type with scalar S and dimension N. Use as 'Rank1VecSN<S,N> auto v'
+	// in abbreviated templates; C++20 prepends the deduced type, producing Rank1VecSN<V,S,N>.
+	// Excludes rank-2 types (matrices) via IsRank1 and rejects mismatched dimension or scalar.
+	template <typename V, typename S, int N>
+	concept Rank1VecSN =
+		IsRank1<std::remove_cvref_t<V>> &&
+		VectorTypeN<std::remove_cvref_t<V>, N> &&
+		std::same_as<typename vector_traits<std::remove_cvref_t<V>>::element_t, S>;
+
 	// Concept to ensure two vector/quaternion types have the same element type
 	template <typename T, typename U>
 	concept SameS = std::is_same_v<typename vector_traits<std::remove_cv_t<T>>::element_t, typename vector_traits<std::remove_cv_t<U>>::element_t>;

--- a/include/pr/math/tests/all_tests.h
+++ b/include/pr/math/tests/all_tests.h
@@ -9,6 +9,7 @@
 #include "pr/math/tests/vector3_tests.h"
 #include "pr/math/tests/vector4_tests.h"
 #include "pr/math/tests/vector8_tests.h"
+#include "pr/math/tests/generic_constructor_tests.h"
 #include "pr/math/tests/matrix2x2_tests.h"
 #include "pr/math/tests/matrix3x3_tests.h"
 #include "pr/math/tests/matrix4x4_tests.h"

--- a/include/pr/math/tests/generic_constructor_tests.h
+++ b/include/pr/math/tests/generic_constructor_tests.h
@@ -1,0 +1,196 @@
+//*****************************************************************************
+// Maths library
+//  Copyright (c) Rylogic Ltd 2002
+//*****************************************************************************
+// Tests for the generic (templated) constructors on Vec2, Vec3, Vec4, and Quat.
+#pragma once
+#include "pr/math/math.h"
+
+#if PR_UNITTESTS
+#include "pr/common/unittests.h"
+
+// External vector types registered via vector_traits outside pr::math.
+// .x/.y/.z/.w members make vector_access_member work without extra glue.
+namespace
+{
+	template <typename T> struct ExtVec2 { T x, y; };
+	template <typename T> struct ExtVec3 { T x, y, z; };
+	template <typename T> struct ExtVec4 { T x, y, z, w; };
+}
+
+namespace pr::math
+{
+	template <typename T> struct vector_traits<ExtVec2<T>>
+		: vector_traits_base<T, T, 2>
+		, vector_access_member<ExtVec2<T>, T, 2>
+	{
+		template <ScalarType S> using rebind = Vec2<S>;
+	};
+	template <typename T> struct vector_traits<ExtVec3<T>>
+		: vector_traits_base<T, T, 3>
+		, vector_access_member<ExtVec3<T>, T, 3>
+	{
+		template <ScalarType S> using rebind = Vec3<S>;
+	};
+	template <typename T> struct vector_traits<ExtVec4<T>>
+		: vector_traits_base<T, T, 4>
+		, vector_access_member<ExtVec4<T>, T, 4>
+	{
+		template <ScalarType S> using rebind = Vec4<S>;
+	};
+}
+
+namespace
+{
+	// A random-access range backed by a pointer pair. Has begin()/end() returning
+	// raw pointers (random-access iterators) but no range-level operator[].
+	// This exercises the iterator-based element-access path in the constructors.
+	template <typename T>
+	struct PtrRange
+	{
+		T const* m_first;
+		T const* m_last;
+
+		T const* begin() const { return m_first; }
+		T const* end()   const { return m_last; }
+	};
+}
+
+namespace pr::math::tests
+{
+	PRUnitTestClass(GenericConstructors)
+	{
+		PRUnitTestMethod(Vec2, float, double, int32_t, int64_t)
+		{
+			// Rank1VecSN constructor: external vector, same scalar, dimension 2
+			auto ext = ExtVec2<T>{T(3), T(7)};
+			Vec2<T> from_ext(ext);
+			PR_EXPECT(from_ext.x == T(3) && from_ext.y == T(7));
+
+			// Constexpr path
+			constexpr auto ext_cx = ExtVec2<T>{T(11), T(22)};
+			constexpr Vec2<T> from_ext_cx(ext_cx);
+			static_assert(from_ext_cx.x == T(11) && from_ext_cx.y == T(22));
+
+			// Range constructor: PtrRange has no range-level operator[]
+			T const data[] = { T(5), T(6), T(99) };
+			PtrRange<T> pr{data, data + 3};
+			Vec2<T> from_range(pr);
+			PR_EXPECT(from_range.x == T(5) && from_range.y == T(6));
+
+			// std::array: sized_range — precondition is checked
+			constexpr std::array<T, 2> arr{T(8), T(9)};
+			constexpr Vec2<T> from_arr(arr);
+			static_assert(from_arr.x == T(8) && from_arr.y == T(9));
+
+			// Unbounded iota: not a sized_range — precondition assert is skipped
+			auto iota = std::views::iota(0);
+			Vec2<T> from_iota(iota);
+			PR_EXPECT(from_iota.x == T(0) && from_iota.y == T(1));
+
+			// Rank-1 guard: Mat2x2 has dimension 2 but is rank-2 — must be rejected
+			static_assert(!std::is_constructible_v<Vec2<T>, Mat2x2<T>>,
+				"Vec2 must not construct from a rank-2 matrix (rank-1 guard)");
+		}
+
+		PRUnitTestMethod(Vec3, float, double, int32_t, int64_t)
+		{
+			// Rank1VecSN constructor
+			auto ext = ExtVec3<T>{T(1), T(2), T(3)};
+			Vec3<T> from_ext(ext);
+			PR_EXPECT(from_ext.x == T(1) && from_ext.y == T(2) && from_ext.z == T(3));
+
+			constexpr auto ext_cx = ExtVec3<T>{T(10), T(20), T(30)};
+			constexpr Vec3<T> from_ext_cx(ext_cx);
+			static_assert(from_ext_cx.x == T(10) && from_ext_cx.y == T(20) && from_ext_cx.z == T(30));
+
+			// Range via PtrRange
+			T const data[] = { T(4), T(5), T(6), T(99) };
+			PtrRange<T> pr{data, data + 4};
+			Vec3<T> from_range(pr);
+			PR_EXPECT(from_range.x == T(4) && from_range.y == T(5) && from_range.z == T(6));
+
+			constexpr std::array<T, 3> arr{T(7), T(8), T(9)};
+			constexpr Vec3<T> from_arr(arr);
+			static_assert(from_arr.x == T(7) && from_arr.y == T(8) && from_arr.z == T(9));
+
+			// Unbounded iota: not a sized_range
+			auto iota = std::views::iota(0);
+			Vec3<T> from_iota(iota);
+			PR_EXPECT(from_iota.x == T(0) && from_iota.y == T(1) && from_iota.z == T(2));
+
+			// Rank-1 guard: Mat3x3 has dimension 3 but is rank-2 — must be rejected
+			static_assert(!std::is_constructible_v<Vec3<T>, Mat3x3<T>>,
+				"Vec3 must not construct from a rank-2 matrix (rank-1 guard)");
+		}
+
+		PRUnitTestMethod(Vec4, float, double, int32_t, int64_t)
+		{
+			// Rank1VecSN constructor
+			auto ext = ExtVec4<T>{T(1), T(2), T(3), T(4)};
+			Vec4<T> from_ext(ext);
+			PR_EXPECT(from_ext.x == T(1) && from_ext.y == T(2) && from_ext.z == T(3) && from_ext.w == T(4));
+
+			constexpr auto ext_cx = ExtVec4<T>{T(10), T(20), T(30), T(40)};
+			constexpr Vec4<T> from_ext_cx(ext_cx);
+			static_assert(from_ext_cx.x == T(10) && from_ext_cx.y == T(20) && from_ext_cx.z == T(30) && from_ext_cx.w == T(40));
+
+			// Range via PtrRange
+			T const data[] = { T(5), T(6), T(7), T(8), T(99) };
+			PtrRange<T> pr{data, data + 5};
+			Vec4<T> from_range(pr);
+			PR_EXPECT(from_range.x == T(5) && from_range.y == T(6) && from_range.z == T(7) && from_range.w == T(8));
+
+			constexpr std::array<T, 4> arr{T(9), T(10), T(11), T(12)};
+			constexpr Vec4<T> from_arr(arr);
+			static_assert(from_arr.x == T(9) && from_arr.y == T(10) && from_arr.z == T(11) && from_arr.w == T(12));
+
+			// Unbounded iota: not a sized_range
+			auto iota = std::views::iota(0);
+			Vec4<T> from_iota(iota);
+			PR_EXPECT(from_iota.x == T(0) && from_iota.y == T(1) && from_iota.z == T(2) && from_iota.w == T(3));
+
+			// Rank-1 guard: Mat4x4 has dimension 4 but is rank-2 — must be rejected
+			static_assert(!std::is_constructible_v<Vec4<T>, Mat4x4<T>>,
+				"Vec4 must not construct from a rank-2 matrix (rank-1 guard)");
+		}
+
+		PRUnitTestMethod(Quat, float, double)
+		{
+			// Rank1VecSN constructor
+			auto ext = ExtVec4<T>{T(0), T(0), T(0), T(1)};
+			Quat<T> from_ext(ext);
+			PR_EXPECT(from_ext.x == T(0) && from_ext.y == T(0) && from_ext.z == T(0) && from_ext.w == T(1));
+
+			// Range via PtrRange
+			T const data[] = { T(0), T(0), T(1), T(0) };
+			PtrRange<T> pr{data, data + 4};
+			Quat<T> from_range(pr);
+			PR_EXPECT(from_range.x == T(0) && from_range.y == T(0) && from_range.z == T(1) && from_range.w == T(0));
+
+			// Unbounded iota: not a sized_range
+			auto iota = std::views::iota(0);
+			Quat<T> from_iota(iota);
+			PR_EXPECT(from_iota.x == T(0) && from_iota.y == T(1) && from_iota.z == T(2) && from_iota.w == T(3));
+
+			// Rank-1 guard: Mat4x4 has dimension 4 but is rank-2 — must be rejected
+			static_assert(!std::is_constructible_v<Quat<T>, Mat4x4<T>>,
+				"Quat must not construct from a rank-2 matrix (rank-1 guard)");
+		}
+
+		// Rank1VecSN requires same_as<element_t, S>, so cross-scalar external types
+		// must not construct (no silent narrowing through this path).
+		PRUnitTestMethod(ScalarConversionPolicy, float)
+		{
+			static_assert(std::is_constructible_v<Vec2<float>, ExtVec2<float>>);
+			static_assert(std::is_constructible_v<Vec3<float>, ExtVec3<float>>);
+			static_assert(std::is_constructible_v<Vec4<float>, ExtVec4<float>>);
+			static_assert(std::is_constructible_v<Quat<float>, ExtVec4<float>>);
+
+			static_assert(!std::is_constructible_v<Vec2<double>, ExtVec2<float>>);
+			static_assert(!std::is_constructible_v<Vec3<double>, ExtVec3<float>>);
+			static_assert(!std::is_constructible_v<Vec4<double>, ExtVec4<float>>);
+		}
+	};
+}
+#endif

--- a/include/pr/math/types/quaternion.h
+++ b/include/pr/math/types/quaternion.h
@@ -48,11 +48,32 @@ namespace pr::math
 			, z(z_)
 			, w(w_)
 		{}
-		constexpr Quat(std::ranges::random_access_range auto&& v) noexcept
-			:Quat(v[0], v[1], v[2], v[3])
-		{}
-		constexpr Quat(VectorTypeN<S, 4> auto v) noexcept
-			:Quat(vec(v).x, vec(v).y, vec(v).z, vec(v).w)
+		// Build from a random-access range. Caller guarantees at least 4 readable elements;
+		// for sized ranges the precondition is checked with pr_assert.
+		template <std::ranges::random_access_range R>
+			requires (!VectorType<std::remove_cvref_t<R>>)
+			      && std::convertible_to<std::ranges::range_reference_t<R>, S>
+		constexpr Quat(R&& v) noexcept
+		{
+			if constexpr (std::ranges::sized_range<R>)
+				pr_assert(std::ranges::size(v) >= 4 && "range must have at least 4 elements");
+			auto it = std::ranges::begin(v);
+			x = static_cast<S>(*it);
+			y = static_cast<S>(*(it + 1));
+			z = static_cast<S>(*(it + 2));
+			w = static_cast<S>(*(it + 3));
+		}
+
+		// Build from a same-scalar external rank-1 vector of dimension 4.
+		// Uses pr::math::vec() (fully qualified) because Quat has a data member
+		// named 'vec' that would otherwise shadow the free function.
+		constexpr Quat(Rank1VecSN<S, 4> auto v) noexcept
+			:Quat(
+				static_cast<S>(pr::math::vec(v).x),
+				static_cast<S>(pr::math::vec(v).y),
+				static_cast<S>(pr::math::vec(v).z),
+				static_cast<S>(pr::math::vec(v).w)
+			)
 		{}
 		constexpr Quat(intrinsic_t vec_) noexcept requires (!NoIntrinsic)
 			:vec(vec_)

--- a/include/pr/math/types/vector2.h
+++ b/include/pr/math/types/vector2.h
@@ -37,11 +37,23 @@ namespace pr::math
 			: x(x_)
 			, y(y_)
 		{}
-		constexpr Vec2(std::ranges::random_access_range auto&& v) noexcept
-			:Vec2(v[0], v[1])
-		{}
-		constexpr explicit Vec2(VectorTypeN<S, 2> auto v) noexcept
-			:Vec2(vec(v).x, vec(v).y)
+		// Build from a random-access range. Caller guarantees at least 2 readable elements;
+		// for sized ranges the precondition is checked with pr_assert.
+		template <std::ranges::random_access_range R>
+			requires (!VectorType<std::remove_cvref_t<R>>)
+			      && std::convertible_to<std::ranges::range_reference_t<R>, S>
+		constexpr Vec2(R&& v) noexcept
+		{
+			if constexpr (std::ranges::sized_range<R>)
+				pr_assert(std::ranges::size(v) >= 2 && "range must have at least 2 elements");
+			auto it = std::ranges::begin(v);
+			x = static_cast<S>(*it);
+			y = static_cast<S>(*(it + 1));
+		}
+
+		// Build from a same-scalar external rank-1 vector of dimension 2.
+		constexpr explicit Vec2(Rank1VecSN<S, 2> auto v) noexcept
+			:Vec2(static_cast<S>(vec(v).x), static_cast<S>(vec(v).y))
 		{}
 		constexpr Vec2(AxisId axis_id) noexcept
 			:Vec2(

--- a/include/pr/math/types/vector3.h
+++ b/include/pr/math/types/vector3.h
@@ -37,8 +37,9 @@ namespace pr::math
 			, y(y_)
 			, z(z_)
 		{}
-		constexpr explicit Vec3(VectorTypeN<S, 3> auto v) noexcept
-			:Vec3(vec(v).x, vec(v).y, vec(v).z)
+		// Build from a same-scalar external rank-1 vector of dimension 3.
+		constexpr explicit Vec3(Rank1VecSN<S, 3> auto v) noexcept
+			:Vec3(static_cast<S>(vec(v).x), static_cast<S>(vec(v).y), static_cast<S>(vec(v).z))
 		{}
 		constexpr Vec3(Vec2<S> v, S z_) noexcept
 			:Vec3(v.x, v.y, z_)
@@ -50,9 +51,20 @@ namespace pr::math
 				Abs(axis_id) == AxisId::PosZ ? static_cast<S>(Sign<int>(axis_id)) : S(0)
 			)
 		{}
-		constexpr Vec3(std::ranges::random_access_range auto&& v) noexcept
-			:Vec3(v[0], v[1], v[2])
-		{}
+		// Build from a random-access range. Caller guarantees at least 3 readable elements;
+		// for sized ranges the precondition is checked with pr_assert.
+		template <std::ranges::random_access_range R>
+			requires (!VectorType<std::remove_cvref_t<R>>)
+			      && std::convertible_to<std::ranges::range_reference_t<R>, S>
+		constexpr Vec3(R&& v) noexcept
+		{
+			if constexpr (std::ranges::sized_range<R>)
+				pr_assert(std::ranges::size(v) >= 3 && "range must have at least 3 elements");
+			auto it = std::ranges::begin(v);
+			x = static_cast<S>(*it);
+			y = static_cast<S>(*(it + 1));
+			z = static_cast<S>(*(it + 2));
+		}
 
 		// Explicit cast to different Scalar type
 		template <ScalarType S2> constexpr explicit operator Vec3<S2>() const noexcept

--- a/include/pr/math/types/vector4.h
+++ b/include/pr/math/types/vector4.h
@@ -61,8 +61,16 @@ namespace pr::math
 			, z(z_)
 			, w(S(0))
 		{}
-		constexpr Vec4(VectorTypeN<S, 4> auto v) noexcept
-			:Vec4(vec(v).x, vec(v).y, vec(v).z, vec(v).w)
+		// Build from a same-scalar external rank-1 vector of dimension 4.
+		// Uses pr::math::vec() (fully qualified) because Vec4 has a data member
+		// named 'vec' that would otherwise shadow the free function.
+		constexpr Vec4(Rank1VecSN<S, 4> auto v) noexcept
+			:Vec4(
+				static_cast<S>(pr::math::vec(v).x),
+				static_cast<S>(pr::math::vec(v).y),
+				static_cast<S>(pr::math::vec(v).z),
+				static_cast<S>(pr::math::vec(v).w)
+			)
 		{}
 		constexpr Vec4(Vec3<S> v, S w_) noexcept
 			:Vec4(v.x, v.y, v.z, w_)
@@ -84,9 +92,21 @@ namespace pr::math
 		constexpr Vec4(intrinsic_t vec_) noexcept requires (!NoIntrinsic)
 			:vec(vec_)
 		{}
-		constexpr Vec4(std::ranges::random_access_range auto&& v) noexcept
-			:Vec4(v[0], v[1], v[2], v[3])
-		{}
+		// Build from a random-access range. Caller guarantees at least 4 readable elements;
+		// for sized ranges the precondition is checked with pr_assert.
+		template <std::ranges::random_access_range R>
+			requires (!VectorType<std::remove_cvref_t<R>>)
+			      && std::convertible_to<std::ranges::range_reference_t<R>, S>
+		constexpr Vec4(R&& v) noexcept
+		{
+			if constexpr (std::ranges::sized_range<R>)
+				pr_assert(std::ranges::size(v) >= 4 && "range must have at least 4 elements");
+			auto it = std::ranges::begin(v);
+			x = static_cast<S>(*it);
+			y = static_cast<S>(*(it + 1));
+			z = static_cast<S>(*(it + 2));
+			w = static_cast<S>(*(it + 3));
+		}
 
 		// Explicit cast to different Scalar type
 		template <ScalarType S2> constexpr explicit operator Vec4<S2>() const noexcept

--- a/projects/tests/unittests/src/unittests.h
+++ b/projects/tests/unittests/src/unittests.h
@@ -121,6 +121,7 @@
 #include "pr/math/tests/dynamics_tests.h"
 #include "pr/math/tests/frustum_tests.h"
 #include "pr/math/tests/function_tests.h"
+#include "pr/math/tests/generic_constructor_tests.h"
 #include "pr/math/tests/half_tests.h"
 #include "pr/math/tests/interpolate_tests.h"
 #include "pr/math/tests/matrix_tests.h"


### PR DESCRIPTION
## Summary

Fixes two correctness bugs in the generic constructors of `Vec2`, `Vec3`, `Vec4`, and `Quat` that were discovered during a header-only audit. A third latent bug was revealed once the first was fixed.

---

## Bug 1 — `VectorTypeN<S,N> auto` C++20 concept misuse

**Root cause:** In C++20 abbreviated concept syntax, `Concept<A,B> auto v` *prepends* the deduced type as the first argument. So `VectorTypeN<S,N> auto v` expands to `VectorTypeN<deduced_type, S, N>` — three arguments for a two-parameter concept `<typename T, int N>`. MSVC silently SFINAE's this out, making the constructor always unselected. External rank-1 vector types registered via `vector_traits` could never be used to construct a `Vec2/3/4/Quat`.

**Fix:** Added a new three-parameter concept `Rank1VecSN<V,S,N>` to `traits.h`. Now `Rank1VecSN<S,N> auto v` correctly expands to `Rank1VecSN<deduced_type, S, N>`. The concept also includes an `IsRank1<V>` guard to reject rank-2 matrices.

## Bug 2 — Range constructor uses `v[i]` subscript

**Root cause:** `std::ranges::random_access_range` only guarantees the *iterator* supports random-access (`+n`, `-n`, etc.). It does **not** require the range itself to have `operator[]`. Using `v[0]`, `v[1]`, etc. in the constructor body fails to compile for valid custom ranges (e.g. a pointer-backed `begin`/`end` pair with no subscript operator).

**Fix:** All range constructors now access elements through the range's iterator: `auto it = std::ranges::begin(v); x = *it; y = *(it+1);`. A `!VectorType<R>` constraint guards against ambiguity with VectorType ranges. A `pr_assert` precondition documents the minimum-size requirement.

## Bug 3 (latent) — `vec` member shadows `pr::math::vec()` free function

**Root cause:** Both `Vec4` and `Quat` have a SIMD union member named `vec`. Inside their constructor bodies, unqualified `vec(v)` binds to the data member, not the free function `pr::math::vec()`. This was previously latent because Bug 1 made the constructor unreachable.

**Fix:** Use fully-qualified `pr::math::vec(v)` in `Vec4` and `Quat` constructor bodies. Vec2 and Vec3 have no `vec` member and are unaffected.

---

## Changes

| File | Change |
|------|--------|
| `include/pr/math/core/traits.h` | Add `Rank1VecSN<V,S,N>` concept |
| `include/pr/math/types/vector2.h` | Fix range constructor (iterator access + `!VectorType` guard); fix VectorType constructor concept |
| `include/pr/math/types/vector3.h` | Same fixes for dimension 3 |
| `include/pr/math/types/vector4.h` | Same fixes for dimension 4; use `pr::math::vec()` in body |
| `include/pr/math/types/quaternion.h` | Same fixes for Quat; use `pr::math::vec()` in body |
| `include/pr/math/tests/generic_constructor_tests.h` | **New** — focused tests for all four types |
| `include/pr/math/tests/all_tests.h` | Include new test file |

---

## Tests

New file `generic_constructor_tests.h` covers:
- `ExtVec2/3/4<T>` — external types with `vector_traits` specialisations. Verify Rank1VecSN construction works, scalar policy is enforced, and rank-2 matrices are rejected at compile time.
- `PtrRange<T>` — custom random-access range with `begin`/`end` iterators but **no** `operator[]`. Verifies the iterator-based range constructor works for all four types.
- Covers `Vec2`, `Vec3`, `Vec4`, `Quat`, scalar conversion policy, `constexpr` where supported.

---

## Verification

Manually compiled and executed the following with VS 2026 / v145 / `/std:c++latest`:
- The new `Rank1VecSN`-constrained constructors correctly accept `ExtVec4<float>` and reject `Mat4x4<float>` at compile time.
- The `PtrRange<float>` range constructor compiles and produces correct values.
- Existing `std::array`, `std::span`, and C-array construction continues to work without change.