### PR TITLE
Fix matrix range constructors

### DIFF
--- a/include/pr/math/tests/generic_constructor_tests.h
+++ b/include/pr/math/tests/generic_constructor_tests.h
@@ -5,6 +5,7 @@
 // Tests for the generic (templated) constructors on Vec2, Vec3, Vec4, and Quat.
 #pragma once
 #include "pr/math/math.h"
+#include "pr/math/tests/range_test_helpers.h"
 
 #if PR_UNITTESTS
 #include "pr/common/unittests.h"
@@ -37,22 +38,6 @@ namespace pr::math
 		, vector_access_member<ExtVec4<T>, T, 4>
 	{
 		template <ScalarType S> using rebind = Vec4<S>;
-	};
-}
-
-namespace
-{
-	// A random-access range backed by a pointer pair. Has begin()/end() returning
-	// raw pointers (random-access iterators) but no range-level operator[].
-	// This exercises the iterator-based element-access path in the constructors.
-	template <typename T>
-	struct PtrRange
-	{
-		T const* m_first;
-		T const* m_last;
-
-		T const* begin() const { return m_first; }
-		T const* end()   const { return m_last; }
 	};
 }
 

--- a/include/pr/math/tests/matrix2x2_tests.h
+++ b/include/pr/math/tests/matrix2x2_tests.h
@@ -4,6 +4,7 @@
 //*****************************************************************************
 #pragma once
 #include "pr/math/math.h"
+#include "pr/math/tests/range_test_helpers.h"
 
 #if PR_UNITTESTS
 #include "pr/common/unittests.h"
@@ -42,7 +43,7 @@ namespace pr::math::tests
 			PR_EXPECT(All(from_span.x == vec2_t(T(9), T(10))));
 			PR_EXPECT(All(from_span.y == vec2_t(T(11), T(12))));
 
-			// PtrRange comes from generic_constructor_tests.h and has no range-level operator[].
+			// PtrRange is a pointer-pair helper with no range-level operator[].
 			T const ptr_data[] = { T(13), T(14), T(15), T(16), T(99) };
 			PtrRange<T> ptr_range{ ptr_data, ptr_data + 4 };
 			mat2_t from_ptr_range(ptr_range);

--- a/include/pr/math/tests/matrix2x2_tests.h
+++ b/include/pr/math/tests/matrix2x2_tests.h
@@ -31,6 +31,33 @@ namespace pr::math::tests
 			static_assert(All(V2.x == vec2_t(T(5), T(6))));
 			static_assert(All(V2.y == vec2_t(T(7), T(8))));
 
+			// From std::array and std::span
+			constexpr std::array<T, 4> array_values{ T(9), T(10), T(11), T(12) };
+			constexpr mat2_t from_array(array_values);
+			static_assert(All(from_array.x == vec2_t(T(9), T(10))));
+			static_assert(All(from_array.y == vec2_t(T(11), T(12))));
+
+			std::span<T const> span_values{ array_values };
+			mat2_t from_span(span_values);
+			PR_EXPECT(All(from_span.x == vec2_t(T(9), T(10))));
+			PR_EXPECT(All(from_span.y == vec2_t(T(11), T(12))));
+
+			// PtrRange comes from generic_constructor_tests.h and has no range-level operator[].
+			T const ptr_data[] = { T(13), T(14), T(15), T(16), T(99) };
+			PtrRange<T> ptr_range{ ptr_data, ptr_data + 4 };
+			mat2_t from_ptr_range(ptr_range);
+			PR_EXPECT(All(from_ptr_range.x == vec2_t(T(13), T(14))));
+			PR_EXPECT(All(from_ptr_range.y == vec2_t(T(15), T(16))));
+
+			// Unbounded iota is not sized, so the constructor must not ask for distance.
+			auto iota_range = std::views::iota(0);
+			mat2_t from_iota(iota_range);
+			PR_EXPECT(All(from_iota.x == vec2_t(T(0), T(1))));
+			PR_EXPECT(All(from_iota.y == vec2_t(T(2), T(3))));
+
+			// Non-convertible references are rejected at compile time.
+			static_assert(!std::is_constructible_v<mat2_t, std::array<char const*, 4> const&>);
+
 			// Array access
 			static_assert(All(V0[0] == vec2_t(T(1), T(2))));
 			static_assert(All(V0[1] == vec2_t(T(3), T(4))));

--- a/include/pr/math/tests/matrix3x3_tests.h
+++ b/include/pr/math/tests/matrix3x3_tests.h
@@ -4,6 +4,7 @@
 //*****************************************************************************
 #pragma once
 #include "pr/math/math.h"
+#include "pr/math/tests/range_test_helpers.h"
 
 #if PR_UNITTESTS
 #include "pr/common/unittests.h"
@@ -55,7 +56,7 @@ namespace pr::math::tests
 			PR_EXPECT(All(from_span.y == vec3_t(T(13), T(14), T(15))));
 			PR_EXPECT(All(from_span.z == vec3_t(T(16), T(17), T(18))));
 
-			// PtrRange comes from generic_constructor_tests.h and has no range-level operator[].
+			// PtrRange is a pointer-pair helper with no range-level operator[].
 			T const ptr_data[] = { T(19), T(20), T(21), T(22), T(23), T(24), T(25), T(26), T(27), T(99) };
 			PtrRange<T> ptr_range{ ptr_data, ptr_data + 9 };
 			mat3_t from_ptr_range(ptr_range);

--- a/include/pr/math/tests/matrix3x3_tests.h
+++ b/include/pr/math/tests/matrix3x3_tests.h
@@ -42,6 +42,37 @@ namespace pr::math::tests
 			auto M3 = mat3_t(arr);
 			PR_EXPECT(All(M3.x == M1.x) && All(M3.y == M1.y) && All(M3.z == M1.z));
 
+			// From std::array and std::span
+			constexpr std::array<T, 9> array_values{ T(10), T(11), T(12), T(13), T(14), T(15), T(16), T(17), T(18) };
+			constexpr mat3_t from_array(array_values);
+			static_assert(All(from_array.x == vec3_t(T(10), T(11), T(12))));
+			static_assert(All(from_array.y == vec3_t(T(13), T(14), T(15))));
+			static_assert(All(from_array.z == vec3_t(T(16), T(17), T(18))));
+
+			std::span<T const> span_values{ array_values };
+			mat3_t from_span(span_values);
+			PR_EXPECT(All(from_span.x == vec3_t(T(10), T(11), T(12))));
+			PR_EXPECT(All(from_span.y == vec3_t(T(13), T(14), T(15))));
+			PR_EXPECT(All(from_span.z == vec3_t(T(16), T(17), T(18))));
+
+			// PtrRange comes from generic_constructor_tests.h and has no range-level operator[].
+			T const ptr_data[] = { T(19), T(20), T(21), T(22), T(23), T(24), T(25), T(26), T(27), T(99) };
+			PtrRange<T> ptr_range{ ptr_data, ptr_data + 9 };
+			mat3_t from_ptr_range(ptr_range);
+			PR_EXPECT(All(from_ptr_range.x == vec3_t(T(19), T(20), T(21))));
+			PR_EXPECT(All(from_ptr_range.y == vec3_t(T(22), T(23), T(24))));
+			PR_EXPECT(All(from_ptr_range.z == vec3_t(T(25), T(26), T(27))));
+
+			// Unbounded iota is not sized, so the constructor must not ask for distance.
+			auto iota_range = std::views::iota(0);
+			mat3_t from_iota(iota_range);
+			PR_EXPECT(All(from_iota.x == vec3_t(T(0), T(1), T(2))));
+			PR_EXPECT(All(from_iota.y == vec3_t(T(3), T(4), T(5))));
+			PR_EXPECT(All(from_iota.z == vec3_t(T(6), T(7), T(8))));
+
+			// Non-convertible references are rejected at compile time.
+			static_assert(!std::is_constructible_v<mat3_t, std::array<char const*, 9> const&>);
+
 			// Array access (returns Vec3)
 			PR_EXPECT(All(M1[0] == M1.x));
 			PR_EXPECT(All(M1[1] == M1.y));

--- a/include/pr/math/tests/range_test_helpers.h
+++ b/include/pr/math/tests/range_test_helpers.h
@@ -1,0 +1,27 @@
+//*****************************************************************************
+// Maths library
+//  Copyright (c) Rylogic Ltd 2002
+//*****************************************************************************
+#pragma once
+
+#if PR_UNITTESTS
+namespace pr::math::tests
+{
+	// Pointer-pair range with random-access iterators but no range-level operator[].
+	template <typename T>
+	struct PtrRange
+	{
+		T const* m_first;
+		T const* m_last;
+
+		T const* begin() const
+		{
+			return m_first;
+		}
+		T const* end() const
+		{
+			return m_last;
+		}
+	};
+}
+#endif

--- a/include/pr/math/types/matrix2x2.h
+++ b/include/pr/math/types/matrix2x2.h
@@ -37,11 +37,20 @@ namespace pr::math
 			:x(x_)
 			,y(y_)
 		{}
-		constexpr Mat2x2(std::ranges::random_access_range auto&& v) noexcept
-			:Mat2x2(
-				Vec2<S>(v[0], v[1]),
-				Vec2<S>(v[2], v[3]))
-		{}
+		// Build from a random-access range. Caller guarantees at least 4 readable elements;
+		// for sized ranges the precondition is checked with pr_assert.
+		template <std::ranges::random_access_range R>
+			requires (!VectorType<std::remove_cvref_t<R>>)
+			      && std::convertible_to<std::ranges::range_reference_t<R>, S>
+		constexpr Mat2x2(R&& v) noexcept
+		{
+			if constexpr (std::ranges::sized_range<R>)
+				pr_assert(std::ranges::size(v) >= 4 && "range must have at least 4 elements");
+
+			auto it = std::ranges::begin(v);
+			x = Vec2<S>(static_cast<S>(*it), static_cast<S>(*(it + 1)));
+			y = Vec2<S>(static_cast<S>(*(it + 2)), static_cast<S>(*(it + 3)));
+		}
 
 		// Explicit cast to different Scalar type
 		template <ScalarType S2> constexpr explicit operator Mat2x2<S2>() const noexcept

--- a/include/pr/math/types/matrix3x3.h
+++ b/include/pr/math/types/matrix3x3.h
@@ -47,11 +47,22 @@ namespace pr::math
 			,y(y_.x, y_.y, y_.z), yw()
 			,z(z_.x, z_.y, z_.z), zw()
 		{}
-		constexpr Mat3x3(std::ranges::random_access_range auto&& v) noexcept // 9 scalars
-			:x(v[0], v[1], v[2]), xw()
-			,y(v[3], v[4], v[5]), yw()
-			,z(v[6], v[7], v[8]), zw()
-		{}
+		// Build from a random-access range. Caller guarantees at least 9 readable elements;
+		// for sized ranges the precondition is checked with pr_assert.
+		template <std::ranges::random_access_range R>
+			requires (!VectorType<std::remove_cvref_t<R>>)
+			      && std::convertible_to<std::ranges::range_reference_t<R>, S>
+		constexpr Mat3x3(R&& v) noexcept
+		{
+			if constexpr (std::ranges::sized_range<R>)
+				pr_assert(std::ranges::size(v) >= 9 && "range must have at least 9 elements");
+
+			auto it = std::ranges::begin(v);
+			x = Vec3<S>(static_cast<S>(*it), static_cast<S>(*(it + 1)), static_cast<S>(*(it + 2)));
+			y = Vec3<S>(static_cast<S>(*(it + 3)), static_cast<S>(*(it + 4)), static_cast<S>(*(it + 5)));
+			z = Vec3<S>(static_cast<S>(*(it + 6)), static_cast<S>(*(it + 7)), static_cast<S>(*(it + 8)));
+			xw = yw = zw = S(0);
+		}
 
 		// Explicit cast to different Scalar type
 		template <ScalarType S2> constexpr explicit operator Mat3x3<S2>() const noexcept


### PR DESCRIPTION
Fix Mat2x2 and Mat3x3 range constructors so they read through begin()/iterator offsets instead of indexing the range object. The constructors now require convertible range references, check sized ranges for the minimum element count, and leave unsized ranges to the caller precondition.

Tests cover pointer-pair ranges without operator[], std::array/span inputs, unbounded iota ranges, and non-convertible element references.