### PR TITLE
Fix Mat4x4 constexpr union access

### DIFF
--- a/include/pr/math/tests/matrix4x4_tests.h
+++ b/include/pr/math/tests/matrix4x4_tests.h
@@ -133,6 +133,52 @@ namespace pr::math::tests
 			PR_EXPECT(All(M1[2] == M1.z));
 			PR_EXPECT(All(M1[3] == M1.w));
 		}
+		PRUnitTestMethod(ConstexprUnionAccess, float, double, int32_t, int64_t)
+		{
+			using vec3_t = Vec3<T>;
+			using vec4_t = Vec4<T>;
+			using mat3_t = Mat3x3<T>;
+			using mat4_t = Mat4x4<T>;
+
+			// Keep the constexpr path on the column view so the canonical union member stays valid.
+			constexpr auto rot = mat3_t(
+				vec3_t(T(1), T(2), T(3)),
+				vec3_t(T(4), T(5), T(6)),
+				vec3_t(T(7), T(8), T(9)));
+			constexpr auto pos = vec4_t(T(10), T(11), T(12), T(1));
+			constexpr auto from_rot = mat4_t(rot, pos);
+			constexpr auto from_rot_expected = mat4_t(
+				vec4_t(T(1), T(2), T(3), T(0)),
+				vec4_t(T(4), T(5), T(6), T(0)),
+				vec4_t(T(7), T(8), T(9), T(0)),
+				pos);
+			static_assert(All(from_rot == from_rot_expected));
+
+			constexpr auto columns = mat4_t(
+				vec4_t(T(1), T(0), T(0), T(0)),
+				vec4_t(T(0), T(1), T(0), T(0)),
+				vec4_t(T(0), T(0), T(1), T(0)),
+				vec4_t(T(10), T(20), T(30), T(1)));
+			constexpr auto vec = vec4_t(T(1), T(2), T(3), T(1));
+			constexpr auto transformed = columns * vec;
+			static_assert(All(transformed == vec4_t(T(11), T(22), T(33), T(1))));
+
+			constexpr auto no_w = columns.w1();
+			constexpr auto no_w_expected = mat4_t(
+				vec4_t(T(1), T(0), T(0), T(0)),
+				vec4_t(T(0), T(1), T(0), T(0)),
+				vec4_t(T(0), T(0), T(1), T(0)),
+				Origin<vec4_t>());
+			static_assert(All(no_w == no_w_expected));
+
+			constexpr auto with_w = columns.w1(vec4_t(T(9), T(8), T(7), T(1)));
+			constexpr auto with_w_expected = mat4_t(
+				vec4_t(T(1), T(0), T(0), T(0)),
+				vec4_t(T(0), T(1), T(0), T(0)),
+				vec4_t(T(0), T(0), T(1), T(0)),
+				vec4_t(T(9), T(8), T(7), T(1)));
+			static_assert(All(with_w == with_w_expected));
+		}
 		PRUnitTestMethod(ColRow, float, double, int32_t, int64_t)
 		{
 			using vec4_t = Vec4<T>;

--- a/include/pr/math/tests/transform_tests.h
+++ b/include/pr/math/tests/transform_tests.h
@@ -29,6 +29,26 @@ namespace pr::math::tests
 
 			PR_EXPECT(FEql(xf1, xf2));
 		}
+		PRUnitTestMethod(ConstexprConversion, float, double)
+		{
+			using xform_t = Xform<T>;
+			using m4x4_t = Mat4x4<T>;
+			using v4_t = Vec4<T>;
+			using quat_t = Quat<T>;
+
+			// Keep the Xform-to-matrix path constexpr on the matrix column view.
+			constexpr auto xf = xform_t(
+				v4_t(T(1), T(2), T(3), T(1)),
+				quat_t(T(0), T(0), T(0), T(1)),
+				v4_t(T(1), T(1), T(1), T(1)));
+			constexpr auto m = m4x4_t(xf);
+			constexpr auto expected = m4x4_t(
+				v4_t(T(1), T(0), T(0), T(0)),
+				v4_t(T(0), T(1), T(0), T(0)),
+				v4_t(T(0), T(0), T(1), T(0)),
+				v4_t(T(1), T(2), T(3), T(1)));
+			static_assert(All(m == expected));
+		}
 		PRUnitTestMethod(Multiply, float, double)
 		{
 			using xform_t = Xform<T>;

--- a/include/pr/math/types/matrix4x4.h
+++ b/include/pr/math/types/matrix4x4.h
@@ -38,6 +38,7 @@ namespace pr::math
 		#pragma warning(disable:4201) // nameless struct
 		union
 		{
+			// x/y/z/w are the active union members for constexpr. rot/pos remains a runtime alias.
 			struct { Vec4<S> x, y, z, w; };
 			struct { Mat3x3<S> rot; Vec4<S> pos; };
 			struct { Vec4<S> arr[4]; };
@@ -66,8 +67,10 @@ namespace pr::math
 		{
 		}
 		constexpr Mat4x4(Mat3x3<S> const& rot_, Vec4<S> pos_) noexcept
-			:rot(rot_)
-			, pos(pos_)
+			: x(rot_.x.w0())
+			, y(rot_.y.w0())
+			, z(rot_.z.w0())
+			, w(pos_)
 		{
 			// Don't assert 'pos.w == 1' here. Not all m4x4's are affine transforms
 		}
@@ -138,12 +141,12 @@ namespace pr::math
 		// Create a 4x4 matrix using just the rotation part of this matrix
 		constexpr Mat4x4 w1() const noexcept
 		{
-			return Mat4x4{ rot, Origin<Vec4<S>>() };
+			return Mat4x4{ x, y, z, Origin<Vec4<S>>() };
 		}
 		constexpr Mat4x4 w1(Vec4<S> xyz) const noexcept
 		{
 			pr_assert(xyz.w == 1 && "'pos' must be a position vector");
-			return Mat4x4{ rot, xyz };
+			return Mat4x4{ x, y, z, xyz };
 		}
 
 		// Return the diagonal elements of this matrix

--- a/include/pr/math/types/transform.h
+++ b/include/pr/math/types/transform.h
@@ -106,10 +106,20 @@ namespace pr::math
 	template <ScalarType S>
 	constexpr Mat4x4<S>::Mat4x4(Xform<S> const& xform) noexcept requires (std::floating_point<S>)
 	{
-		auto rotation = math::ToMatrix<Mat3x3<S>>(xform.rot);
-		auto scale_mat = math::Scale<Mat3x3<S>>(xform.scl.xyz);
-		rot = rotation * scale_mat;
-		pos = xform.pos;
+		auto const& q = xform.rot;
+		auto const norm_sq = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
+		pr_assert(norm_sq != S(0) && "'quat' is a zero quaternion");
+		auto const s = S(2) / norm_sq;
+		auto const xs = q.x * s, ys = q.y * s, zs = q.z * s;
+		auto const wx = q.w * xs, wy = q.w * ys, wz = q.w * zs;
+		auto const xx = q.x * xs, xy = q.x * ys, xz = q.x * zs;
+		auto const yy = q.y * ys, yz = q.y * zs, zz = q.z * zs;
+
+		// Keep the column view active so constexpr callers read the same union member.
+		x = Vec4<S>{ S(1) - (yy + zz), xy + wz, xz - wy, S(0) } * xform.scl.x;
+		y = Vec4<S>{ xy - wz, S(1) - (xx + zz), yz + wx, S(0) } * xform.scl.y;
+		z = Vec4<S>{ xz + wy, yz - wx, S(1) - (xx + yy), S(0) } * xform.scl.z;
+		w = xform.pos;
 	}
 
 	// Approximate equality (absolute tolerance)


### PR DESCRIPTION
Fixes the constexpr matrix4x4 paths to stay on the x/y/z/w union view, and updates the Xform conversion to build the matrix columns directly so it remains constexpr-safe.

Verification: compile-only build of projects/tests/unittests/unittests.vcxproj in Debug x64 succeeded.