### PR TITLE
Fix mat4 quaternion transform

### DIFF
--- a/include/pr/math/tests/matrix4x4_tests.h
+++ b/include/pr/math/tests/matrix4x4_tests.h
@@ -235,22 +235,31 @@ namespace pr::math::tests
 			using vec4_t = Vec4<T>;
 			using quat_t = Quat<T>;
 			using mat4_t = Mat4x4<T>;
+			using other_t = std::conditional_t<std::is_same_v<T, float>, double, float>;
+
+			// The public overload is same-scalar only, so mixed scalar calls are rejected
+			// before the function body is considered.
+			static_assert(requires { mat4_t::Transform(quat_t::Identity(), vec4_t::Origin()); });
+			static_assert(!requires { mat4_t::Transform(Quat<other_t>::Identity(), vec4_t::Origin()); });
 
 			auto q = quat_t(T(1.0), T(0.5), T(0.7));
-			auto m1 = mat4_t::Transform(vec4_t::Normal(T(1), T(0), T(0), T(0)), T(1.0), vec4_t::Origin());
-			auto m2 = mat4_t::Transform(q, vec4_t::Origin());
+			auto pos = vec4_t(T(4), T(-3), T(2), T(1));
+			auto m1 = mat4_t::Transform(vec4_t::Normal(T(1), T(0), T(0), T(0)), T(1.0), pos);
+			auto m2 = mat4_t::Transform(q, pos);
 			PR_EXPECT(IsOrthonormal(m1));
 			PR_EXPECT(IsOrthonormal(m2));
+			PR_EXPECT(FEql(m2 * vec4_t::Origin(), pos));
 
 			// Random axis-angle round-trip
 			std::uniform_real_distribution<T> dist(T(-1), T(1));
 			auto ang = dist(rng);
 			auto axis = vec4_t::Normal(T(1), T(2), T(3), T(0));
-			auto m3 = mat4_t::Transform(axis, ang, vec4_t::Origin());
-			auto m4 = mat4_t::Transform(quat_t(axis, ang), vec4_t::Origin());
+			auto m3 = mat4_t::Transform(axis, ang, pos);
+			auto m4 = mat4_t::Transform(quat_t(axis, ang), pos);
 			PR_EXPECT(IsOrthonormal(m3));
 			PR_EXPECT(IsOrthonormal(m4));
 			PR_EXPECT(FEql(m3, m4));
+			PR_EXPECT(FEql(m4 * vec4_t::Origin(), pos));
 		}
 		PRUnitTestMethod(W0, float, double, int32_t, int64_t)
 		{

--- a/include/pr/math/types/matrix4x4.h
+++ b/include/pr/math/types/matrix4x4.h
@@ -190,11 +190,11 @@ namespace pr::math
 			return Mat4x4{ rot, pos };
 		}
 
-		// Create from quaternion + position
-		template <typename Q = S> requires std::floating_point<Q>
-		static Mat4x4 Transform(Quat<Q> q, Vec4<S> pos) noexcept
+		// Create from a same-scalar quaternion + position
+		static Mat4x4 Transform(QuaternionType auto q, Vec4<S> pos) noexcept
+			requires (std::floating_point<S> && SameS<decltype(q), Vec4<S>>)
 		{
-			return Mat4x4{ math::ToMatrix<Mat3x3<Q>>(q), pos };
+			return Mat4x4{ math::ToMatrix<Mat3x3<S>>(q), pos };
 		}
 
 		// Create from an axis and angle. 'axis' should be normalised


### PR DESCRIPTION
Make the quaternion-based Mat4x4 transform overload same-scalar and floating-point only, and add compile-time/runtime coverage for mixed-scalar rejection plus non-origin transform behavior.