### PR TITLE
Fix mat4 quaternion contract

### DIFF
--- a/include/pr/math/types/matrix4x4.h
+++ b/include/pr/math/types/matrix4x4.h
@@ -13,16 +13,15 @@
 namespace pr::math
 {
 	template <typename S, bool = std::floating_point<S>>
-	struct mat4x4_quat_transform
+	struct Mat4x4QuatTransform
 	{
 		static void Transform() = delete;
 	};
 
 	template <typename S>
-	struct mat4x4_quat_transform<S, true>
+	struct Mat4x4QuatTransform<S, true>
 	{
-		// Keep the quaternion overload exact for floating-point matrices without
-		// forcing integer specialisations to form an invalid Quat<int> type.
+		// Create from a same-scalar quaternion + position
 		static Mat4x4<S> Transform(Quat<S> q, Vec4<S> pos) noexcept
 		{
 			return Mat4x4<S>{ math::ToMatrix<Mat3x3<S>>(q), pos };
@@ -31,7 +30,7 @@ namespace pr::math
 
 	template <ScalarType S>
 	struct Mat4x4
-		: mat4x4_quat_transform<S>
+		: Mat4x4QuatTransform<S>
 	{
 		// Notes:
 		//  - Matrix members 'x, y, z, w' are column vectors stored contigously.
@@ -63,7 +62,7 @@ namespace pr::math
 		};
 		#pragma warning(pop)
 
-		using mat4x4_quat_transform<S>::Transform;
+		using Mat4x4QuatTransform<S>::Transform;
 
 		// Construct
 		constexpr Mat4x4() noexcept

--- a/include/pr/math/types/matrix4x4.h
+++ b/include/pr/math/types/matrix4x4.h
@@ -12,8 +12,26 @@
 
 namespace pr::math
 {
+	template <typename S, bool = std::floating_point<S>>
+	struct mat4x4_quat_transform
+	{
+		static void Transform() = delete;
+	};
+
+	template <typename S>
+	struct mat4x4_quat_transform<S, true>
+	{
+		// Keep the quaternion overload exact for floating-point matrices without
+		// forcing integer specialisations to form an invalid Quat<int> type.
+		static Mat4x4<S> Transform(Quat<S> q, Vec4<S> pos) noexcept
+		{
+			return Mat4x4<S>{ math::ToMatrix<Mat3x3<S>>(q), pos };
+		}
+	};
+
 	template <ScalarType S>
 	struct Mat4x4
+		: mat4x4_quat_transform<S>
 	{
 		// Notes:
 		//  - Matrix members 'x, y, z, w' are column vectors stored contigously.
@@ -44,6 +62,8 @@ namespace pr::math
 			struct { Vec4<S> arr[4]; };
 		};
 		#pragma warning(pop)
+
+		using mat4x4_quat_transform<S>::Transform;
 
 		// Construct
 		constexpr Mat4x4() noexcept
@@ -191,13 +211,6 @@ namespace pr::math
 		static Mat4x4 Transform(Mat3x3<S> const& rot, Vec4<S> pos) noexcept
 		{
 			return Mat4x4{ rot, pos };
-		}
-
-		// Create from a same-scalar quaternion + position
-		static Mat4x4 Transform(QuaternionType auto q, Vec4<S> pos) noexcept
-			requires (std::floating_point<S> && SameS<decltype(q), Vec4<S>>)
-		{
-			return Mat4x4{ math::ToMatrix<Mat3x3<S>>(q), pos };
 		}
 
 		// Create from an axis and angle. 'axis' should be normalised

--- a/include/pr/math/types/matrix4x4.h
+++ b/include/pr/math/types/matrix4x4.h
@@ -12,25 +12,8 @@
 
 namespace pr::math
 {
-	template <typename S, bool = std::floating_point<S>>
-	struct Mat4x4QuatTransform
-	{
-		static void Transform() = delete;
-	};
-
-	template <typename S>
-	struct Mat4x4QuatTransform<S, true>
-	{
-		// Create from a same-scalar quaternion + position
-		static Mat4x4<S> Transform(Quat<S> q, Vec4<S> pos) noexcept
-		{
-			return Mat4x4<S>{ math::ToMatrix<Mat3x3<S>>(q), pos };
-		}
-	};
-
 	template <ScalarType S>
 	struct Mat4x4
-		: Mat4x4QuatTransform<S>
 	{
 		// Notes:
 		//  - Matrix members 'x, y, z, w' are column vectors stored contigously.
@@ -61,8 +44,6 @@ namespace pr::math
 			struct { Vec4<S> arr[4]; };
 		};
 		#pragma warning(pop)
-
-		using Mat4x4QuatTransform<S>::Transform;
 
 		// Construct
 		constexpr Mat4x4() noexcept
@@ -210,6 +191,14 @@ namespace pr::math
 		static Mat4x4 Transform(Mat3x3<S> const& rot, Vec4<S> pos) noexcept
 		{
 			return Mat4x4{ rot, pos };
+		}
+
+		// Create from a same-scalar quaternion + position
+		template <typename Q>
+			requires (std::same_as<Q, S> && std::floating_point<Q>)
+		static Mat4x4 Transform(Quat<Q> q, Vec4<S> pos) noexcept
+		{
+			return Mat4x4{ math::ToMatrix<Mat3x3<S>>(q), pos };
 		}
 
 		// Create from an axis and angle. 'axis' should be normalised


### PR DESCRIPTION
Follow-up to keep the quaternion-based Mat4x4 transform overload exact for same-scalar floating-point matrices while preserving integer Mat4x4 instantiations. The merged matrix4x4 tests already cover same-scalar float/double calls, mixed-scalar rejection, and non-origin runtime behavior.