### PR TITLE
Fix canonical Mat4x4 constexpr paths

### DIFF
--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -3677,26 +3677,72 @@ namespace pr::math
 	{
 		using vt = vector_traits<Mat>;
 		using S = typename vt::element_t;
+		using Vec = typename vt::component_t;
 
-		Mat mat = {};
-		if constexpr (vt::dimension > 0) vec(vec(mat).x).x = scale;
-		if constexpr (vt::dimension > 1) vec(vec(mat).y).y = scale;
-		if constexpr (vt::dimension > 2) vec(vec(mat).z).z = scale;
-		if constexpr (vt::dimension > 3) vec(vec(mat).w).w = scale;
-		return mat;
+		if constexpr (vt::dimension == 2)
+		{
+			return Mat{
+				Vec{ scale, S(0) },
+				Vec{ S(0), scale }
+			};
+		}
+		else if constexpr (vt::dimension == 3)
+		{
+			return Mat{
+				Vec{ scale, S(0), S(0) },
+				Vec{ S(0), scale, S(0) },
+				Vec{ S(0), S(0), scale }
+			};
+		}
+		else if constexpr (vt::dimension == 4)
+		{
+			return Mat{
+				Vec{ scale, S(0), S(0), S(0) },
+				Vec{ S(0), scale, S(0), S(0) },
+				Vec{ S(0), S(0), scale, S(0) },
+				Vec{ S(0), S(0), S(0), scale }
+			};
+		}
+		else
+		{
+			static_assert(vt::dimension <= 4);
+		}
 	}
 	template <VectorType Mat> requires (IsRank2<Mat>)
 	constexpr Mat pr_vectorcall Scale(typename vector_traits<Mat>::component_t scale) noexcept
 	{
 		using vt = vector_traits<Mat>;
 		using S = typename vt::element_t;
+		using Vec = typename vt::component_t;
 
-		Mat mat = {};
-		if constexpr (vt::dimension > 0) vec(vec(mat).x).x = vec(scale).x;
-		if constexpr (vt::dimension > 1) vec(vec(mat).y).y = vec(scale).y;
-		if constexpr (vt::dimension > 2) vec(vec(mat).z).z = vec(scale).z;
-		if constexpr (vt::dimension > 3) vec(vec(mat).w).w = vec(scale).w;
-		return mat;
+		if constexpr (vt::dimension == 2)
+		{
+			return Mat{
+				Vec{ scale.x, S(0) },
+				Vec{ S(0), scale.y }
+			};
+		}
+		else if constexpr (vt::dimension == 3)
+		{
+			return Mat{
+				Vec{ scale.x, S(0), S(0) },
+				Vec{ S(0), scale.y, S(0) },
+				Vec{ S(0), S(0), scale.z }
+			};
+		}
+		else if constexpr (vt::dimension == 4)
+		{
+			return Mat{
+				Vec{ scale.x, S(0), S(0), S(0) },
+				Vec{ S(0), scale.y, S(0), S(0) },
+				Vec{ S(0), S(0), scale.z, S(0) },
+				Vec{ S(0), S(0), S(0), scale.w }
+			};
+		}
+		else
+		{
+			static_assert(vt::dimension <= 4);
+		}
 	}
 
 	// Create a 2D shear matrix

--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -3575,7 +3575,7 @@ namespace pr::math
 		using S = typename vt::element_t;
 		pr_assert(IsNormalised(axis_norm) && "'axis_norm' should be normalised");
 
-		Mat m = {};
+		Mat m = Zero<Mat>();
 		auto trace_vec = axis_norm * (S(1) - cos_angle);
 
 		vec(vec(m).x).x = vec(trace_vec).x * vec(axis_norm).x + cos_angle;
@@ -3679,34 +3679,52 @@ namespace pr::math
 		using S = typename vt::element_t;
 		using Vec = typename vt::component_t;
 
+		// Build the matrix directly through accessors so the helper only depends on vector traits, not matrix constructors.
+		Mat m = {};
 		if constexpr (vt::dimension == 2)
 		{
-			return Mat{
-				Vec{ scale, S(0) },
-				Vec{ S(0), scale }
-			};
+			vec(vec(m).x).x = scale;
+			vec(vec(m).x).y = S(0);
+			vec(vec(m).y).x = S(0);
+			vec(vec(m).y).y = scale;
 		}
 		else if constexpr (vt::dimension == 3)
 		{
-			return Mat{
-				Vec{ scale, S(0), S(0) },
-				Vec{ S(0), scale, S(0) },
-				Vec{ S(0), S(0), scale }
-			};
+			vec(vec(m).x).x = scale;
+			vec(vec(m).x).y = S(0);
+			vec(vec(m).x).z = S(0);
+			vec(vec(m).y).x = S(0);
+			vec(vec(m).y).y = scale;
+			vec(vec(m).y).z = S(0);
+			vec(vec(m).z).x = S(0);
+			vec(vec(m).z).y = S(0);
+			vec(vec(m).z).z = scale;
 		}
 		else if constexpr (vt::dimension == 4)
 		{
-			return Mat{
-				Vec{ scale, S(0), S(0), S(0) },
-				Vec{ S(0), scale, S(0), S(0) },
-				Vec{ S(0), S(0), scale, S(0) },
-				Vec{ S(0), S(0), S(0), scale }
-			};
+			vec(vec(m).x).x = scale;
+			vec(vec(m).x).y = S(0);
+			vec(vec(m).x).z = S(0);
+			vec(vec(m).x).w = S(0);
+			vec(vec(m).y).x = S(0);
+			vec(vec(m).y).y = scale;
+			vec(vec(m).y).z = S(0);
+			vec(vec(m).y).w = S(0);
+			vec(vec(m).z).x = S(0);
+			vec(vec(m).z).y = S(0);
+			vec(vec(m).z).z = scale;
+			vec(vec(m).z).w = S(0);
+			vec(vec(m).w).x = S(0);
+			vec(vec(m).w).y = S(0);
+			vec(vec(m).w).z = S(0);
+			vec(vec(m).w).w = scale;
 		}
 		else
 		{
 			static_assert(vt::dimension <= 4);
 		}
+
+		return m;
 	}
 	template <VectorType Mat> requires (IsRank2<Mat>)
 	constexpr Mat pr_vectorcall Scale(typename vector_traits<Mat>::component_t scale) noexcept
@@ -3715,34 +3733,52 @@ namespace pr::math
 		using S = typename vt::element_t;
 		using Vec = typename vt::component_t;
 
+		// Build the matrix directly through accessors so the helper stays generic over matrix and vector traits.
+		Mat m = {};
 		if constexpr (vt::dimension == 2)
 		{
-			return Mat{
-				Vec{ scale.x, S(0) },
-				Vec{ S(0), scale.y }
-			};
+			vec(vec(m).x).x = vec(scale).x;
+			vec(vec(m).x).y = S(0);
+			vec(vec(m).y).x = S(0);
+			vec(vec(m).y).y = vec(scale).y;
 		}
 		else if constexpr (vt::dimension == 3)
 		{
-			return Mat{
-				Vec{ scale.x, S(0), S(0) },
-				Vec{ S(0), scale.y, S(0) },
-				Vec{ S(0), S(0), scale.z }
-			};
+			vec(vec(m).x).x = vec(scale).x;
+			vec(vec(m).x).y = S(0);
+			vec(vec(m).x).z = S(0);
+			vec(vec(m).y).x = S(0);
+			vec(vec(m).y).y = vec(scale).y;
+			vec(vec(m).y).z = S(0);
+			vec(vec(m).z).x = S(0);
+			vec(vec(m).z).y = S(0);
+			vec(vec(m).z).z = vec(scale).z;
 		}
 		else if constexpr (vt::dimension == 4)
 		{
-			return Mat{
-				Vec{ scale.x, S(0), S(0), S(0) },
-				Vec{ S(0), scale.y, S(0), S(0) },
-				Vec{ S(0), S(0), scale.z, S(0) },
-				Vec{ S(0), S(0), S(0), scale.w }
-			};
+			vec(vec(m).x).x = vec(scale).x;
+			vec(vec(m).x).y = S(0);
+			vec(vec(m).x).z = S(0);
+			vec(vec(m).x).w = S(0);
+			vec(vec(m).y).x = S(0);
+			vec(vec(m).y).y = vec(scale).y;
+			vec(vec(m).y).z = S(0);
+			vec(vec(m).y).w = S(0);
+			vec(vec(m).z).x = S(0);
+			vec(vec(m).z).y = S(0);
+			vec(vec(m).z).z = vec(scale).z;
+			vec(vec(m).z).w = S(0);
+			vec(vec(m).w).x = S(0);
+			vec(vec(m).w).y = S(0);
+			vec(vec(m).w).z = S(0);
+			vec(vec(m).w).w = vec(scale).w;
 		}
 		else
 		{
 			static_assert(vt::dimension <= 4);
 		}
+
+		return m;
 	}
 
 	// Create a 2D shear matrix

--- a/include/pr/math/core/functions.h
+++ b/include/pr/math/core/functions.h
@@ -3575,7 +3575,7 @@ namespace pr::math
 		using S = typename vt::element_t;
 		pr_assert(IsNormalised(axis_norm) && "'axis_norm' should be normalised");
 
-		Mat m = Zero<Mat>();
+		Mat m = {};
 		auto trace_vec = axis_norm * (S(1) - cos_angle);
 
 		vec(vec(m).x).x = vec(trace_vec).x * vec(axis_norm).x + cos_angle;
@@ -3671,17 +3671,19 @@ namespace pr::math
 		return o2t * InvertOrthonormal(o2f);
 	}
 
-	// Create a scale matrix
+	// Create a scale matrix from a scalar or component vector using only matrix/vector traits.
 	template <VectorType Mat> requires (IsRank2<Mat>)
 	constexpr Mat pr_vectorcall Scale(typename vector_traits<Mat>::element_t scale) noexcept
 	{
 		using vt = vector_traits<Mat>;
 		using S = typename vt::element_t;
-		using Vec = typename vt::component_t;
 
-		// Build the matrix directly through accessors so the helper only depends on vector traits, not matrix constructors.
 		Mat m = {};
-		if constexpr (vt::dimension == 2)
+		if constexpr (vt::dimension == 1)
+		{
+			vec(vec(m).x).x = scale;
+		}
+		else if constexpr (vt::dimension == 2)
 		{
 			vec(vec(m).x).x = scale;
 			vec(vec(m).x).y = S(0);
@@ -3721,7 +3723,7 @@ namespace pr::math
 		}
 		else
 		{
-			static_assert(vt::dimension <= 4);
+			static_assert(vt::dimension >= 1 && vt::dimension <= 4);
 		}
 
 		return m;
@@ -3731,11 +3733,13 @@ namespace pr::math
 	{
 		using vt = vector_traits<Mat>;
 		using S = typename vt::element_t;
-		using Vec = typename vt::component_t;
 
-		// Build the matrix directly through accessors so the helper stays generic over matrix and vector traits.
 		Mat m = {};
-		if constexpr (vt::dimension == 2)
+		if constexpr (vt::dimension == 1)
+		{
+			vec(vec(m).x).x = vec(scale).x;
+		}
+		else if constexpr (vt::dimension == 2)
 		{
 			vec(vec(m).x).x = vec(scale).x;
 			vec(vec(m).x).y = S(0);
@@ -3775,7 +3779,7 @@ namespace pr::math
 		}
 		else
 		{
-			static_assert(vt::dimension <= 4);
+			static_assert(vt::dimension >= 1 && vt::dimension <= 4);
 		}
 
 		return m;

--- a/include/pr/math/tests/function_tests.h
+++ b/include/pr/math/tests/function_tests.h
@@ -217,6 +217,67 @@ namespace pr::math::tests
 			}
 		}
 
+		// Keep the free Scale helper generic over matrix traits and component views.
+		PRUnitTestMethod(ConstexprScale
+		, Mat2x2<float>, Mat2x2<double>, Mat2x2<int32_t>, Mat2x2<int64_t>
+		, Mat3x3<float>, Mat3x3<double>, Mat3x3<int32_t>, Mat3x3<int64_t>
+		, Mat4x4<float>, Mat4x4<double>, Mat4x4<int32_t>, Mat4x4<int64_t>
+		) {
+			using mat_t = T;
+			using vt = vector_traits<mat_t>;
+			using S = typename vt::element_t;
+			using vec_t = typename vt::component_t;
+
+			if constexpr (vt::dimension == 2)
+			{
+				constexpr auto s_scalar = Scale<mat_t>(S(3));
+				constexpr auto s_scalar_expected = mat_t(
+					vec_t(S(3), S(0)),
+					vec_t(S(0), S(3)));
+				static_assert(All(s_scalar == s_scalar_expected));
+
+				constexpr auto s_vec = Scale<mat_t>(vec_t(S(2), S(5)));
+				constexpr auto s_vec_expected = mat_t(
+					vec_t(S(2), S(0)),
+					vec_t(S(0), S(5)));
+				static_assert(All(s_vec == s_vec_expected));
+			}
+			else if constexpr (vt::dimension == 3)
+			{
+				constexpr auto s_scalar = Scale<mat_t>(S(4));
+				constexpr auto s_scalar_expected = mat_t(
+					vec_t(S(4), S(0), S(0)),
+					vec_t(S(0), S(4), S(0)),
+					vec_t(S(0), S(0), S(4)));
+				static_assert(All(s_scalar == s_scalar_expected));
+
+				constexpr auto s_vec = Scale<mat_t>(vec_t(S(2), S(3), S(5)));
+				constexpr auto s_vec_expected = mat_t(
+					vec_t(S(2), S(0), S(0)),
+					vec_t(S(0), S(3), S(0)),
+					vec_t(S(0), S(0), S(5)));
+				static_assert(All(s_vec == s_vec_expected));
+			}
+			else if constexpr (vt::dimension == 4)
+			{
+				constexpr auto s_scalar = Scale<mat_t>(S(6));
+				constexpr auto s_scalar_expected = mat_t(
+					vec_t(S(6), S(0), S(0), S(0)),
+					vec_t(S(0), S(6), S(0), S(0)),
+					vec_t(S(0), S(0), S(6), S(0)),
+					vec_t(S(0), S(0), S(0), S(6)));
+				static_assert(All(s_scalar == s_scalar_expected));
+
+				constexpr auto s_vec = Scale<mat_t>(vec_t(S(2), S(3), S(4), S(5)));
+				constexpr auto s_vec_expected = mat_t(
+					vec_t(S(2), S(0), S(0), S(0)),
+					vec_t(S(0), S(3), S(0), S(0)),
+					vec_t(S(0), S(0), S(4), S(0)),
+					vec_t(S(0), S(0), S(0), S(5)));
+				static_assert(All(s_vec == s_vec_expected));
+			}
+		}
+
 		// ---- Operators (functions.h line ~18) ----
 		PRUnitTestMethod(Operators
 		, Vec2<float>, Vec2<double>, Vec2<int32_t>, Vec2<int64_t>

--- a/include/pr/math/tests/function_tests.h
+++ b/include/pr/math/tests/function_tests.h
@@ -7,6 +7,30 @@
 
 #if PR_UNITTESTS
 #include "pr/common/unittests.h"
+
+namespace
+{
+	// Minimal trait-backed 1x1 types keep the generic Scale helper honest for the smallest rank-2 matrix.
+	template <typename T> struct ExtVec1 { T x; };
+	template <typename T> struct ExtMat1x1 { ExtVec1<T> x; };
+}
+
+namespace pr::math
+{
+	template <typename T> struct vector_traits<ExtVec1<T>>
+		: vector_traits_base<T, T, 1>
+		, vector_access_member<ExtVec1<T>, T, 1>
+	{
+		template <ScalarType S> using rebind = ExtVec1<S>;
+	};
+	template <typename T> struct vector_traits<ExtMat1x1<T>>
+		: vector_traits_base<T, ExtVec1<T>, 1>
+		, vector_access_member<ExtMat1x1<T>, ExtVec1<T>, 1>
+	{
+		template <ScalarType S> using rebind = ExtMat1x1<S>;
+	};
+}
+
 namespace pr::math::tests
 {
 	PRUnitTestClass(FunctionTests)
@@ -217,8 +241,8 @@ namespace pr::math::tests
 			}
 		}
 
-		// Keep the free Scale helper generic over matrix traits and component views.
 		PRUnitTestMethod(ConstexprScale
+		, ExtMat1x1<float>, ExtMat1x1<double>
 		, Mat2x2<float>, Mat2x2<double>, Mat2x2<int32_t>, Mat2x2<int64_t>
 		, Mat3x3<float>, Mat3x3<double>, Mat3x3<int32_t>, Mat3x3<int64_t>
 		, Mat4x4<float>, Mat4x4<double>, Mat4x4<int32_t>, Mat4x4<int64_t>
@@ -228,7 +252,17 @@ namespace pr::math::tests
 			using S = typename vt::element_t;
 			using vec_t = typename vt::component_t;
 
-			if constexpr (vt::dimension == 2)
+			if constexpr (vt::dimension == 1)
+			{
+				constexpr auto s_scalar = Scale<mat_t>(S(3));
+				constexpr auto s_scalar_expected = mat_t{ vec_t{ S(3) } };
+				static_assert(All(s_scalar == s_scalar_expected));
+
+				constexpr auto s_vec = Scale<mat_t>(vec_t{ S(5) });
+				constexpr auto s_vec_expected = mat_t{ vec_t{ S(5) } };
+				static_assert(All(s_vec == s_vec_expected));
+			}
+			else if constexpr (vt::dimension == 2)
 			{
 				constexpr auto s_scalar = Scale<mat_t>(S(3));
 				constexpr auto s_scalar_expected = mat_t(

--- a/include/pr/math/tests/matrix4x4_tests.h
+++ b/include/pr/math/tests/matrix4x4_tests.h
@@ -159,6 +159,10 @@ namespace pr::math::tests
 				vec4_t(T(0), T(1), T(0), T(0)),
 				vec4_t(T(0), T(0), T(1), T(0)),
 				vec4_t(T(10), T(20), T(30), T(1)));
+			static_assert(All(columns.col(0) == columns.x));
+			static_assert(All(columns.col(1) == columns.y));
+			static_assert(All(columns.col(2) == columns.z));
+			static_assert(All(columns.col(3) == columns.w));
 			constexpr auto vec = vec4_t(T(1), T(2), T(3), T(1));
 			constexpr auto transformed = columns * vec;
 			static_assert(All(transformed == vec4_t(T(11), T(22), T(33), T(1))));

--- a/include/pr/math/tests/quaternion_tests.h
+++ b/include/pr/math/tests/quaternion_tests.h
@@ -46,6 +46,23 @@ namespace pr::math::tests
 			// Array access
 			PR_EXPECT(Q0[3] == T(1));
 		}
+
+		// Keep the free ToMatrix helper on the proxy access path for quaternions constructed from raw components.
+		PRUnitTestMethod(ConstexprToMatrix, float, double)
+		{
+			using Quat = Quat<T>;
+			using Vec3 = Vec3<T>;
+			using Mat3x3 = Mat3x3<T>;
+
+			constexpr auto q = Quat(T(0), T(0), T(1), T(1));
+			constexpr auto m = ToMatrix<Mat3x3>(q);
+			constexpr auto expected = Mat3x3(
+				Vec3(T(0), T(1), T(0)),
+				Vec3(T(-1), T(0), T(0)),
+				Vec3(T(0), T(0), T(1)));
+			static_assert(All(m == expected));
+		}
+
 		PRUnitTestMethod(Operators, float, double)
 		{
 			using Quat = Quat<T>;

--- a/include/pr/math/tests/transform_tests.h
+++ b/include/pr/math/tests/transform_tests.h
@@ -36,17 +36,17 @@ namespace pr::math::tests
 			using v4_t = Vec4<T>;
 			using quat_t = Quat<T>;
 
-			// Keep the Xform-to-matrix path constexpr on the matrix column view.
+			// Keep the Xform-to-matrix path constexpr on a non-trivial rotation and scale.
 			constexpr auto xf = xform_t(
-				v4_t(T(1), T(2), T(3), T(1)),
-				quat_t(T(0), T(0), T(0), T(1)),
-				v4_t(T(1), T(1), T(1), T(1)));
+				v4_t(T(5), T(6), T(7), T(1)),
+				quat_t(T(0), T(0), T(1), T(1)),
+				v4_t(T(2), T(3), T(4), T(1)));
 			constexpr auto m = m4x4_t(xf);
 			constexpr auto expected = m4x4_t(
-				v4_t(T(1), T(0), T(0), T(0)),
-				v4_t(T(0), T(1), T(0), T(0)),
-				v4_t(T(0), T(0), T(1), T(0)),
-				v4_t(T(1), T(2), T(3), T(1)));
+				v4_t(T(0), T(2), T(0), T(0)),
+				v4_t(T(-3), T(0), T(0), T(0)),
+				v4_t(T(0), T(0), T(4), T(0)),
+				v4_t(T(5), T(6), T(7), T(1)));
 			static_assert(All(m == expected));
 		}
 		PRUnitTestMethod(Multiply, float, double)

--- a/include/pr/math/types/matrix4x4.h
+++ b/include/pr/math/types/matrix4x4.h
@@ -120,7 +120,7 @@ namespace pr::math
 		// Get/Set by row or column. Note: x,y,z are column vectors
 		constexpr Vec4<S> col(int i) const noexcept
 		{
-			return arr[i];
+			return (*this)[i];
 		}
 		constexpr Vec4<S> row(int i) const noexcept
 		{

--- a/include/pr/math/types/quaternion.h
+++ b/include/pr/math/types/quaternion.h
@@ -505,14 +505,17 @@ namespace pr::math
 		using mt = vector_traits<Mat>;
 		using Vec = typename mt::component_t;
 		using S = typename qt::element_t;
-		auto const norm_sq = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
+
+		// Stay on the proxy/view access path so the helper works with quaternions that only expose traits.
+		auto const qv = vec(q);
+		auto const norm_sq = qv.x * qv.x + qv.y * qv.y + qv.z * qv.z + qv.w * qv.w;
 		pr_assert(norm_sq != S(0) && "'quat' is a zero quaternion");
 
 		auto const s = S(2) / norm_sq;
-		S xs = q.x * s, ys = q.y * s, zs = q.z * s;
-		S wx = q.w * xs, wy = q.w * ys, wz = q.w * zs;
-		S xx = q.x * xs, xy = q.x * ys, xz = q.x * zs;
-		S yy = q.y * ys, yz = q.y * zs, zz = q.z * zs;
+		S xs = qv.x * s, ys = qv.y * s, zs = qv.z * s;
+		S wx = qv.w * xs, wy = qv.w * ys, wz = qv.w * zs;
+		S xx = qv.x * xs, xy = qv.x * ys, xz = qv.x * zs;
+		S yy = qv.y * ys, yz = qv.y * zs, zz = qv.z * zs;
 	
 		Mat m = {};
 		vec(m).x = Vec{S(1) - (yy + zz), xy + wz, xz - wy};

--- a/include/pr/math/types/quaternion.h
+++ b/include/pr/math/types/quaternion.h
@@ -505,13 +505,14 @@ namespace pr::math
 		using mt = vector_traits<Mat>;
 		using Vec = typename mt::component_t;
 		using S = typename qt::element_t;
-		pr_assert(LengthSq(q.xyzw) != 0 && "'quat' is a zero quaternion");
+		auto const norm_sq = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
+		pr_assert(norm_sq != S(0) && "'quat' is a zero quaternion");
 
-		auto s = S(2) / LengthSq(q.xyzw);
-		S xs = vec(q).x *  s, ys = vec(q).y *  s, zs = vec(q).z *  s;
-		S wx = vec(q).w * xs, wy = vec(q).w * ys, wz = vec(q).w * zs;
-		S xx = vec(q).x * xs, xy = vec(q).x * ys, xz = vec(q).x * zs;
-		S yy = vec(q).y * ys, yz = vec(q).y * zs, zz = vec(q).z * zs;
+		auto const s = S(2) / norm_sq;
+		S xs = q.x * s, ys = q.y * s, zs = q.z * s;
+		S wx = q.w * xs, wy = q.w * ys, wz = q.w * zs;
+		S xx = q.x * xs, xy = q.x * ys, xz = q.x * zs;
+		S yy = q.y * ys, yz = q.y * zs, zz = q.z * zs;
 	
 		Mat m = {};
 		vec(m).x = Vec{S(1) - (yy + zz), xy + wz, xz - wy};

--- a/include/pr/math/types/transform.h
+++ b/include/pr/math/types/transform.h
@@ -104,14 +104,16 @@ namespace pr::math
 
 	// Deferred definition of Mat4x4(Xform) constructor
 	template <ScalarType S>
-	constexpr Mat4x4<S> Mat4x4FromXform(Xform<S> const& xform) noexcept requires (std::floating_point<S>)
-	{
-		return Mat4x4<S>{ ToMatrix<Mat3x3<S>>(xform.rot) * Scale<Mat3x3<S>>(Vec3<S>{ xform.scl.x, xform.scl.y, xform.scl.z }), xform.pos };
-	}
-
-	template <ScalarType S>
 	constexpr Mat4x4<S>::Mat4x4(Xform<S> const& xform) noexcept requires (std::floating_point<S>)
-		: Mat4x4(Mat4x4FromXform(xform))
+		: Mat4x4(
+			[&xform]
+			{
+				using mat3_t = Mat3x3<S>;
+				using vec3_t = Vec3<S>;
+
+				return ::pr::math::template ToMatrix<mat3_t>(xform.rot) * ::pr::math::template Scale<mat3_t>(vec3_t{ xform.scl.x, xform.scl.y, xform.scl.z });
+			}(),
+			xform.pos)
 	{
 	}
 

--- a/include/pr/math/types/transform.h
+++ b/include/pr/math/types/transform.h
@@ -104,22 +104,15 @@ namespace pr::math
 
 	// Deferred definition of Mat4x4(Xform) constructor
 	template <ScalarType S>
-	constexpr Mat4x4<S>::Mat4x4(Xform<S> const& xform) noexcept requires (std::floating_point<S>)
+	constexpr Mat4x4<S> Mat4x4FromXform(Xform<S> const& xform) noexcept requires (std::floating_point<S>)
 	{
-		auto const& q = xform.rot;
-		auto const norm_sq = q.x * q.x + q.y * q.y + q.z * q.z + q.w * q.w;
-		pr_assert(norm_sq != S(0) && "'quat' is a zero quaternion");
-		auto const s = S(2) / norm_sq;
-		auto const xs = q.x * s, ys = q.y * s, zs = q.z * s;
-		auto const wx = q.w * xs, wy = q.w * ys, wz = q.w * zs;
-		auto const xx = q.x * xs, xy = q.x * ys, xz = q.x * zs;
-		auto const yy = q.y * ys, yz = q.y * zs, zz = q.z * zs;
+		return Mat4x4<S>{ ToMatrix<Mat3x3<S>>(xform.rot) * Scale<Mat3x3<S>>(Vec3<S>{ xform.scl.x, xform.scl.y, xform.scl.z }), xform.pos };
+	}
 
-		// Keep the column view active so constexpr callers read the same union member.
-		x = Vec4<S>{ S(1) - (yy + zz), xy + wz, xz - wy, S(0) } * xform.scl.x;
-		y = Vec4<S>{ xy - wz, S(1) - (xx + zz), yz + wx, S(0) } * xform.scl.y;
-		z = Vec4<S>{ xz + wy, yz - wx, S(1) - (xx + yy), S(0) } * xform.scl.z;
-		w = xform.pos;
+	template <ScalarType S>
+	constexpr Mat4x4<S>::Mat4x4(Xform<S> const& xform) noexcept requires (std::floating_point<S>)
+		: Mat4x4(Mat4x4FromXform(xform))
+	{
 	}
 
 	// Approximate equality (absolute tolerance)

--- a/include/pr/math/types/transform.h
+++ b/include/pr/math/types/transform.h
@@ -106,13 +106,8 @@ namespace pr::math
 	template <ScalarType S>
 	constexpr Mat4x4<S>::Mat4x4(Xform<S> const& xform) noexcept requires (std::floating_point<S>)
 		: Mat4x4(
-			[&xform]
-			{
-				using mat3_t = Mat3x3<S>;
-				using vec3_t = Vec3<S>;
-
-				return ::pr::math::template ToMatrix<mat3_t>(xform.rot) * ::pr::math::template Scale<mat3_t>(vec3_t{ xform.scl.x, xform.scl.y, xform.scl.z });
-			}(),
+			::pr::math::template ToMatrix<Mat3x3<S>>(xform.rot) *
+			::pr::math::template Scale<Mat3x3<S>>(Vec3<S>{ xform.scl.x, xform.scl.y, xform.scl.z }),
 			xform.pos)
 	{
 	}


### PR DESCRIPTION
Follow-up to the merged Mat4x4 constexpr fix.

Keeps constexpr construction on the canonical column view, routes `Mat4x4(Xform)` through the shared helpers, tightens the `col()` constexpr path, and adds exact regression coverage for the nontrivial Xform conversion case.