### PR TITLE
Fix spatial dual-space tagging

### DIFF
--- a/include/pr/math/spatial/spatial.h
+++ b/include/pr/math/spatial/spatial.h
@@ -48,6 +48,14 @@ namespace pr::math::spatial
 	struct Motion {};
 	struct Force {};
 
+	namespace detail
+	{
+		// Treat CPM inputs as motion vectors only. The result-space tag selects the matrix form.
+		template <typename T> struct IsMotionVector : std::false_type {};
+		template <ScalarType S> struct IsMotionVector<Vec8<S, Motion>> : std::true_type {};
+		template <typename T> inline constexpr bool IsMotionVector_v = IsMotionVector<std::remove_cvref_t<T>>::value;
+	}
+
 	#pragma region Operators
 
 	// Rotate a spatial motion vector
@@ -131,7 +139,7 @@ namespace pr::math::spatial
 	}
 
 	// Spatial cross product.
-	// There are two cross product operators, one for motion vectors (rx) and one for forces (rx*)
+	// There are two cross product operators, one for motion/motion pairs (rx) and one for motion/force pairs (rx*)
 	template <ScalarTypeFP S> constexpr Vec8<S, Motion> pr_vectorcall Cross(Vec8<S, Motion> lhs, Vec8<S, Motion> rhs) noexcept
 	{
 		return Vec8<S, Motion>{
@@ -139,7 +147,7 @@ namespace pr::math::spatial
 			Cross(lhs.ang, rhs.lin) + Cross(lhs.lin, rhs.ang)
 		};
 	}
-	template <ScalarTypeFP S> constexpr Vec8<S, Force> pr_vectorcall Cross(Vec8<S, Force> lhs, Vec8<S, Force> rhs) noexcept
+	template <ScalarTypeFP S> constexpr Vec8<S, Force> pr_vectorcall Cross(Vec8<S, Motion> lhs, Vec8<S, Force> rhs) noexcept
 	{
 		return Vec8<S, Force>{
 			Cross(lhs.ang, rhs.ang) + Cross(lhs.lin, rhs.lin),
@@ -176,22 +184,23 @@ namespace pr::math::spatial
 		};
 	}
 
-	// Returns the spatial cross product matrix for 'a', for use with motion vectors.
-	//' i.e. b = a x m = CPM(a) * m, where m is a motion vector
-	template <ScalarTypeFP S> constexpr Mat6x8<S, Motion, Motion> CPM(Vec8<S, Motion> a) noexcept
+	// Returns the spatial cross product matrix for 'a'.
+	// The default result is motion-space; `CPM<Force>(a)` selects the dual force-space matrix for the same motion input.
+	template <typename VecSpace = Motion, typename Vec = void>
+	requires (
+		detail::IsMotionVector_v<Vec> &&
+		(std::same_as<VecSpace, Motion> || std::same_as<VecSpace, Force>)
+	)
+	constexpr auto CPM(Vec const& a) noexcept
 	{
-		auto cx_ang = math::CPM<Mat3x3<S>>(a.ang.xyz);
-		auto cx_lin = math::CPM<Mat3x3<S>>(a.lin.xyz);
-		return Mat6x8<S, Motion, Motion>(cx_ang, Zero<Mat3x3<S>>(), cx_lin, cx_ang);
-	}
+		using S = typename vector_traits<std::remove_cvref_t<decltype(a.ang)>>::element_t;
 
-	// Returns the spatial cross product matrix for 'a', for use with force vectors.
-	// i.e. b = a x* f = CPM(a) * f, where f is a force vector
-	template <ScalarTypeFP S> constexpr Mat6x8<S, Force, Force> CPM(Vec8<S, Force> a) noexcept
-	{
 		auto cx_ang = math::CPM<Mat3x3<S>>(a.ang.xyz);
 		auto cx_lin = math::CPM<Mat3x3<S>>(a.lin.xyz);
-		return Mat6x8<S, Force, Force>(cx_ang, cx_lin, Zero<Mat3x3<S>>(), cx_ang);
+		if constexpr (std::same_as<VecSpace, Motion>)
+			return Mat6x8<S, Motion, Motion>(cx_ang, Zero<Mat3x3<S>>(), cx_lin, cx_ang);
+		else
+			return Mat6x8<S, Force, Force>(cx_ang, cx_lin, Zero<Mat3x3<S>>(), cx_ang);
 	}
 
 	// Create a spatial coordinate transform
@@ -237,6 +246,23 @@ namespace pr::math::spatial::tests
 		//	v4 ang(4,3,2,0);
 		//	auto o2w = Mat4x4::Transform(v4::ZAxis(), float(maths::tau_by_4), v4(1,1,1,1));
 		}
+		// Compile-time API coverage for the spatial dual-space overloads.
+		PRUnitTestMethod(ApiConstraints, float, double)
+		{
+			using v8motionT = Vec8<T, Motion>;
+			using v8forceT = Vec8<T, Force>;
+
+			// Compile-time coverage for the accepted spatial overloads.
+			static_assert(std::same_as<decltype(Cross(v8motionT{}, v8motionT{})), v8motionT>);
+			static_assert(std::same_as<decltype(Cross(v8motionT{}, v8forceT{})), v8forceT>);
+			static_assert(std::same_as<decltype(CPM(v8motionT{})), Mat6x8<T, Motion, Motion>>);
+			static_assert(std::same_as<decltype(CPM<Force>(v8motionT{})), Mat6x8<T, Force, Force>>);
+
+			// And compile-time rejection for the combinations that are no longer part of the API.
+			static_assert(!requires(v8forceT const& f) { Cross(f, f); });
+			static_assert(!requires(v8forceT const& f) { CPM<Force>(f); });
+			static_assert(!requires(v8motionT const& m) { CPM<void>(m); });
+		}
 		PRUnitTestMethod(CrossProducts, float, double)
 		{
 			using v8motionT = Vec8<T, Motion>;
@@ -249,17 +275,18 @@ namespace pr::math::spatial::tests
 				auto r1 = CPM(v0) * v1;
 				PR_EXPECT(FEql(r0, r1));
 			}
-			{// Test: CPM(f) * a == f x* a
-				auto v0 = v8forceT(1, 1, 1, 2, 2, 2);
+			{// Test: CPM<Force>(m) * f == m x* f
+				auto v0 = v8motionT(1, 1, 1, 2, 2, 2);
 				auto v1 = v8forceT(-1, -2, -3, -4, -5, -6);
 				auto r0 = Cross(v0, v1);
-				auto r1 = CPM(v0) * v1;
+				auto r1 = CPM<Force>(v0) * v1;
 				PR_EXPECT(FEql(r0, r1));
 			}
 			{// Test: vx* == -Transpose(vx)
 				auto v = Vec8<T, void>(-2.3f, +1.3f, 0.9f, -2.2f, 0.0f, -1.0f);
-				auto m0 = CPM(static_cast<v8motionT>(v)); // vx
-				auto m1 = CPM(static_cast<v8forceT>(v)); // vx*
+				auto m = static_cast<v8motionT>(v);
+				auto m0 = CPM(m); // vx
+				auto m1 = CPM<Force>(m); // vx*
 				auto m2 = Transpose(m1);
 				auto m3 = static_cast<Mat6x8<T, Motion, Motion>>(-m2);
 				PR_EXPECT(FEql(m0, m3));

--- a/include/pr/math/spatial/spatial.h
+++ b/include/pr/math/spatial/spatial.h
@@ -48,14 +48,6 @@ namespace pr::math::spatial
 	struct Motion {};
 	struct Force {};
 
-	namespace detail
-	{
-		// Treat CPM inputs as motion vectors only. The result-space tag selects the matrix form.
-		template <typename T> struct IsMotionVector : std::false_type {};
-		template <ScalarType S> struct IsMotionVector<Vec8<S, Motion>> : std::true_type {};
-		template <typename T> inline constexpr bool IsMotionVector_v = IsMotionVector<std::remove_cvref_t<T>>::value;
-	}
-
 	#pragma region Operators
 
 	// Rotate a spatial motion vector
@@ -186,14 +178,10 @@ namespace pr::math::spatial
 
 	// Returns the spatial cross product matrix for 'a'.
 	// The default result is motion-space; `CPM<Force>(a)` selects the dual force-space matrix for the same motion input.
-	template <typename VecSpace = Motion, typename Vec = void>
-	requires (
-		detail::IsMotionVector_v<Vec> &&
-		(std::same_as<VecSpace, Motion> || std::same_as<VecSpace, Force>)
-	)
-	constexpr auto CPM(Vec const& a) noexcept
+	template <typename VecSpace = Motion, ScalarTypeFP S = float>
+	requires (std::same_as<VecSpace, Motion> || std::same_as<VecSpace, Force>)
+	constexpr Mat6x8<S, VecSpace, VecSpace> CPM(Vec8<S, Motion> a) noexcept
 	{
-		using S = typename vector_traits<std::remove_cvref_t<decltype(a.ang)>>::element_t;
 
 		auto cx_ang = math::CPM<Mat3x3<S>>(a.ang.xyz);
 		auto cx_lin = math::CPM<Mat3x3<S>>(a.lin.xyz);
@@ -246,19 +234,27 @@ namespace pr::math::spatial::tests
 		//	v4 ang(4,3,2,0);
 		//	auto o2w = Mat4x4::Transform(v4::ZAxis(), float(maths::tau_by_4), v4(1,1,1,1));
 		}
-		// Compile-time API coverage for the spatial dual-space overloads.
 		PRUnitTestMethod(ApiConstraints, float, double)
 		{
 			using v8motionT = Vec8<T, Motion>;
 			using v8forceT = Vec8<T, Force>;
 
-			// Compile-time coverage for the accepted spatial overloads.
+			// Compile-time coverage for the accepted and rejected spatial overloads.
+			auto can_cpm_with_integer_motion = []<typename U>() consteval
+			{
+				using int_motionT = Vec8<U, Motion>;
+				return requires (int_motionT const& v)
+				{
+					CPM(v);
+				};
+			};
+
 			static_assert(std::same_as<decltype(Cross(v8motionT{}, v8motionT{})), v8motionT>);
 			static_assert(std::same_as<decltype(Cross(v8motionT{}, v8forceT{})), v8forceT>);
 			static_assert(std::same_as<decltype(CPM(v8motionT{})), Mat6x8<T, Motion, Motion>>);
 			static_assert(std::same_as<decltype(CPM<Force>(v8motionT{})), Mat6x8<T, Force, Force>>);
 
-			// And compile-time rejection for the combinations that are no longer part of the API.
+			static_assert(!can_cpm_with_integer_motion.template operator()<int>());
 			static_assert(!requires(v8forceT const& f) { Cross(f, f); });
 			static_assert(!requires(v8forceT const& f) { CPM<Force>(f); });
 			static_assert(!requires(v8motionT const& m) { CPM<void>(m); });

--- a/projects/rylogic/Rylogic.Core/src/Maths/Spatial/Spatial.cs
+++ b/projects/rylogic/Rylogic.Core/src/Maths/Spatial/Spatial.cs
@@ -279,19 +279,19 @@ namespace Rylogic.Maths
 
 		/// <summary>
 		/// Spatial cross product.
-		/// There are two cross product operations, one for motion vectors and one for forces</summary>
-		public static v8<Motion> Cross<T>(v8<T> lhs, v8<Motion> rhs) where T: IVectorSpace
+		/// There are two cross product operations, one for motion/motion pairs and one for motion/force pairs</summary>
+		public static v8<Motion> Cross(v8<Motion> lhs, v8<Motion> rhs)
 		{
 			return new v8<Motion>(Cross(lhs.ang, rhs.ang), Cross(lhs.ang, rhs.lin) + Cross(lhs.lin, rhs.ang));
 		}
-		public static v8<Force> Cross<T>(v8<T> lhs, v8<Force> rhs) where T: IVectorSpace
+		public static v8<Force> Cross(v8<Motion> lhs, v8<Force> rhs)
 		{
 			return new v8<Force>(Cross(lhs.ang, rhs.ang) + Cross(lhs.lin, rhs.lin), Cross(lhs.ang, rhs.lin));
 		}
 
 		/// <summary>
-		/// The spatial cross product matrix for 'a', for use with motion vectors.
-		///' i.e. b = a x m = CPM(a) * m, where m is a motion vector</summary>
+		/// The spatial cross product matrix for 'a'.
+		/// The default result is motion-space; `CPM<Force>(a)` selects the dual force-space matrix for the same motion input.</summary>
 		public static m6x8<Motion,Motion> CPM(v8<Motion> a)
 		{
 			var cx_ang = CPM(a.ang.xyz);
@@ -300,13 +300,13 @@ namespace Rylogic.Maths
 		}
 
 		/// <summary>
-		/// The spatial cross product matrix for 'a', for use with force vectors.
-		/// i.e. b = a x* f = CPM(a) * f, where f is a force vector</summary>
-		public static m6x8<Force, Force> CPM(v8<Force> a)
+		/// The dual spatial cross product matrix for a motion vector.
+		/// The generic tag selects the force-space matrix form.</summary>
+		public static m6x8<T, T> CPM<T>(v8<Motion> a) where T : Force
 		{
 			var cx_ang = CPM(a.ang.xyz);
 			var cx_lin = CPM(a.lin.xyz);
-			return new m6x8<Force, Force>(cx_ang, cx_lin, m3x3.Zero, cx_ang);
+			return new m6x8<T, T>(cx_ang, cx_lin, m3x3.Zero, cx_ang);
 		}
 
 		/// <summary>Return the transpose of a spatial matrix</summary>
@@ -354,10 +354,10 @@ namespace Rylogic.UnitTests
 				Assert.True(Math_.FEql(r0, r1));
 			}
 			{
-				var v0 = new v8<Force>(1, 1, 1, 2, 2, 2);
+				var v0 = new v8<Motion>(1, 1, 1, 2, 2, 2);
 				var v1 = new v8<Force>(-1, -2, -3, -4, -5, -6);
 				var r0 = Math_.Cross(v0, v1);
-				var r1 = Math_.CPM(v0) * v1;
+				var r1 = Math_.CPM<Force>(v0) * v1;
 				Assert.True(Math_.FEql(r0, r1));
 			}
 			{// Test: vx* == -Transpose(vx)
@@ -365,7 +365,7 @@ namespace Rylogic.UnitTests
 				var v = v8<IVectorSpace>.Random(-5f, +5f, rng);
 
 				var m0 = Math_.CPM(v.Cast<Motion>()); // vx
-				var m1 = Math_.CPM(v.Cast<Force>());  // vx*
+				var m1 = Math_.CPM<Force>(v.Cast<Motion>());  // vx*
 				var m2 = Math_.Transpose(m1);
 				var m3 = (-m2).Cast<Motion,Motion>();
 				Assert.True(Math_.FEql(m0, m3));

--- a/projects/rylogic/physics/reference/05-spatial-cross-products.md
+++ b/projects/rylogic/physics/reference/05-spatial-cross-products.md
@@ -19,8 +19,7 @@ $$\hat{\mathbf{a}} \times \hat{\mathbf{b}} = \begin{bmatrix} \boldsymbol{\omega}
 
 In Rylogic:
 ```cpp
-template <typename T>
-Vec8f<Motion> Cross(Vec8f<T> const& lhs, Vec8f<Motion> const& rhs)
+Vec8f<Motion> Cross(Vec8f<Motion> const& lhs, Vec8f<Motion> const& rhs)
 {
     return Vec8f<Motion>(
         Cross3(lhs.ang, rhs.ang),                                // ω_a × ω_b
@@ -38,8 +37,7 @@ $$\hat{\mathbf{a}} \times^{*} \hat{\mathbf{b}} = \begin{bmatrix} \boldsymbol{\om
 
 In Rylogic:
 ```cpp
-template <typename T>
-Vec8f<Force> Cross(Vec8f<T> const& lhs, Vec8f<Force> const& rhs)
+Vec8f<Force> Cross(Vec8f<Motion> const& lhs, Vec8f<Force> const& rhs)
 {
     return Vec8f<Force>(
         Cross3(lhs.ang, rhs.ang) + Cross3(lhs.lin, rhs.lin),    // ω_a × τ_b + v_a × f_b
@@ -59,8 +57,9 @@ In other words, the force cross-product matrix is the **negative transpose** of 
 ```cpp
 {// Test: vx* == -Transpose(vx)
     auto v = v8(-2.3f, +1.3f, 0.9f, -2.2f, 0.0f, -1.0f);
-    auto m0 = CPM(static_cast<v8motion>(v)); // vx
-    auto m1 = CPM(static_cast<v8force>(v));  // vx*
+    auto m = static_cast<v8motion>(v);
+    auto m0 = CPM(m);        // vx
+    auto m1 = CPM<Force>(m); // vx*
     auto m2 = Transpose(m1);
     auto m3 = static_cast<m6x8m>(-m2);
     PR_EXPECT(FEql(m0, m3));
@@ -90,7 +89,7 @@ Mat6x8f<Motion,Motion> CPM(Vec8f<Motion> const& a)
 $$[\hat{\mathbf{a}}]_{\times^{*}} = \begin{bmatrix} [\boldsymbol{\omega}_a]_{\times} & [\mathbf{v}_a]_{\times} \\ 0 & [\boldsymbol{\omega}_a]_{\times} \end{bmatrix}$$
 
 ```cpp
-Mat6x8f<Force,Force> CPM(Vec8f<Force> const& a)
+Mat6x8f<Force,Force> CPM<Force>(Vec8f<Motion> const& a)
 {
     auto cx_ang = CPM(a.ang);
     auto cx_lin = CPM(a.lin);


### PR DESCRIPTION
Fix the spatial dual-space API so the force cross product is selected from a motion input via CPM<Force>(motion) and the default CPM(motion) remains motion-space. Also tighten the managed mirror, update focused tests, and refresh the spatial reference example.