### PR TITLE
Constrain spatial transform tags

### DIFF
--- a/include/pr/math/spatial/spatial.h
+++ b/include/pr/math/spatial/spatial.h
@@ -194,10 +194,11 @@ namespace pr::math::spatial
 		return Mat6x8<S, Force, Force>(cx_ang, cx_lin, Zero<Mat3x3<S>>(), cx_ang);
 	}
 
-	// Create a spatial coordinate transform
+	// Spatial vector-space tags supported by coordinate transforms.
 	template <typename VecSpace>
 	concept SpatialVecSpace = std::same_as<VecSpace, Motion> || std::same_as<VecSpace, Force>;
 
+	// Create a spatial coordinate transform.
 	template <typename VecSpace, ScalarTypeFP S>
 		requires SpatialVecSpace<VecSpace>
 	constexpr Mat6x8<S, VecSpace, VecSpace> Transform(Mat4x4<S> const& a2b) noexcept

--- a/include/pr/math/spatial/spatial.h
+++ b/include/pr/math/spatial/spatial.h
@@ -195,17 +195,24 @@ namespace pr::math::spatial
 	}
 
 	// Create a spatial coordinate transform
-	template <typename VecSpace, ScalarTypeFP S> constexpr Mat6x8<S, VecSpace, VecSpace> Transform(Mat4x4<S> const& a2b) noexcept
+	template <typename VecSpace>
+	concept SpatialVecSpace = std::same_as<VecSpace, Motion> || std::same_as<VecSpace, Force>;
+
+	template <typename VecSpace, ScalarTypeFP S>
+		requires SpatialVecSpace<VecSpace>
+	constexpr Mat6x8<S, VecSpace, VecSpace> Transform(Mat4x4<S> const& a2b) noexcept
 	{
 		// Note: RBDA shows a transform to be (with r = a2b.pos):
 		//  [ E    0] = motion         [E   r^E]
 		//  [r^E   E]          force = [0    E ]
 		if constexpr (std::same_as<VecSpace, Motion>)
+		{
 			return Mat6x8<S, Motion, Motion>{a2b.rot, Zero<Mat3x3<S>>(), math::CPM<Mat3x3<S>>(a2b.pos.xyz) * a2b.rot, a2b.rot};
-		else if constexpr (std::same_as<VecSpace, Force>)
-			return Mat6x8<S, Force, Force>{a2b.rot, math::CPM<Mat3x3<S>>(a2b.pos.xyz) * a2b.rot, Zero<Mat3x3<S>>(), a2b.rot};
+		}
 		else
-			static_assert(std::is_same_v<VecSpace, void>, "Invalid VecSpace");
+		{
+			return Mat6x8<S, Force, Force>{a2b.rot, math::CPM<Mat3x3<S>>(a2b.pos.xyz) * a2b.rot, Zero<Mat3x3<S>>(), a2b.rot};
+		}
 	}
 
 	// Spatial inertia matrix

--- a/include/pr/math/tests/spatial_tests.h
+++ b/include/pr/math/tests/spatial_tests.h
@@ -17,23 +17,17 @@ namespace pr::math::spatial::tests
 		{
 		};
 
-		template <typename VecSpace, typename = void>
-		struct HasTransform : std::false_type
-		{
-		};
-
 		template <typename VecSpace>
-		struct HasTransform<VecSpace, std::void_t<decltype(Transform<VecSpace>(std::declval<m4f const&>()))>> : std::true_type
+		concept HasSpatialTransform = requires(m4f const& value)
 		{
+			Transform<VecSpace>(value);
 		};
 
 		// Keep the public transform overload exact: only the spatial tags are valid call targets.
 		static_assert(std::same_as<decltype(Transform<Motion>(std::declval<m4f const&>())), Mat6x8<float, Motion, Motion>>);
 		static_assert(std::same_as<decltype(Transform<Force>(std::declval<m4f const&>())), Mat6x8<float, Force, Force>>);
-		static_assert(HasTransform<Motion>::value);
-		static_assert(HasTransform<Force>::value);
-		static_assert(!HasTransform<void>::value);
-		static_assert(!HasTransform<UnrelatedTag>::value);
+		static_assert(!HasSpatialTransform<void>);
+		static_assert(!HasSpatialTransform<UnrelatedTag>);
 	}
 
 	PRUnitTestClass(SpatialAlgebraTests)

--- a/include/pr/math/tests/spatial_tests.h
+++ b/include/pr/math/tests/spatial_tests.h
@@ -9,6 +9,33 @@
 #include "pr/common/unittests.h"
 namespace pr::math::spatial::tests
 {
+	namespace
+	{
+		using m4f = Mat4x4<float>;
+
+		struct UnrelatedTag
+		{
+		};
+
+		template <typename VecSpace, typename = void>
+		struct HasTransform : std::false_type
+		{
+		};
+
+		template <typename VecSpace>
+		struct HasTransform<VecSpace, std::void_t<decltype(Transform<VecSpace>(std::declval<m4f const&>()))>> : std::true_type
+		{
+		};
+
+		// Keep the public transform overload exact: only the spatial tags are valid call targets.
+		static_assert(std::same_as<decltype(Transform<Motion>(std::declval<m4f const&>())), Mat6x8<float, Motion, Motion>>);
+		static_assert(std::same_as<decltype(Transform<Force>(std::declval<m4f const&>())), Mat6x8<float, Force, Force>>);
+		static_assert(HasTransform<Motion>::value);
+		static_assert(HasTransform<Force>::value);
+		static_assert(!HasTransform<void>::value);
+		static_assert(!HasTransform<UnrelatedTag>::value);
+	}
+
 	PRUnitTestClass(SpatialAlgebraTests)
 	{
 		PRUnitTestMethod(CrossProduct, float, double)


### PR DESCRIPTION
Tighten Transform<VecSpace>(Mat4x4) so only Motion and Force are viable, and add compile-time coverage for the accepted and rejected tag cases.