### PR TITLE
Fix Vec8 constexpr indexing

### DIFF
--- a/include/pr/math/tests/vector8_tests.h
+++ b/include/pr/math/tests/vector8_tests.h
@@ -39,6 +39,43 @@ namespace pr::math::tests
 			PR_EXPECT(FEql(z.ang, vec4_t(0, 0, 0, 0)));
 			PR_EXPECT(FEql(z.lin, vec4_t(0, 0, 0, 0)));
 		}
+		// Constant-evaluation indexing must stay on the active union view.
+		PRUnitTestMethod(ConstexprIndexing, float, double, int32_t, int64_t)
+		{
+			using vec8_t = Vec8<T, void>;
+
+			// Read every indexed component at compile time so both sub-vectors are exercised.
+			static_assert([]() constexpr
+			{
+				constexpr vec8_t v = vec8_t{
+					T(1), T(2), T(3), T(4),
+					T(5), T(6), T(7), T(8)
+				};
+
+				return
+					v[0] == T(1) &&
+					v[1] == T(2) &&
+					v[2] == T(3) &&
+					v[3] == T(4) &&
+					v[4] == T(5) &&
+					v[5] == T(6) &&
+					v[6] == T(7) &&
+					v[7] == T(8);
+			}());
+
+			// Write through the indexed setter in constant evaluation so the mutable overload
+			// follows the same active-member path.
+			static_assert([]() constexpr
+			{
+				auto v = vec8_t{
+					T(1), T(2), T(3), T(4),
+					T(5), T(6), T(7), T(8)
+				};
+
+				v[5] = T(42);
+				return v[5] == T(42) && v[4] == T(5) && v[6] == T(7);
+			}());
+		}
 
 		PRUnitTestMethod(LinAt_AngAt, float, double)
 		{

--- a/include/pr/math/tests/vector8_tests.h
+++ b/include/pr/math/tests/vector8_tests.h
@@ -43,6 +43,7 @@ namespace pr::math::tests
 		PRUnitTestMethod(ConstexprIndexing, float, double, int32_t, int64_t)
 		{
 			using vec8_t = Vec8<T, void>;
+			static_assert(std::same_as<decltype(std::declval<vec8_t const&>()[0]), T const&>);
 
 			// Read every indexed component at compile time so both sub-vectors are exercised.
 			static_assert([]() constexpr

--- a/include/pr/math/types/vector8.h
+++ b/include/pr/math/types/vector8.h
@@ -85,15 +85,23 @@ namespace pr::math
 		}
 
 		// Array access
-		constexpr S operator [] (int i) const noexcept
+		// Keep constexpr access on the active union members; the runtime path still uses the
+		// contiguous array alias.
+		constexpr S const& operator [] (int i) const noexcept
 		{
 			pr_assert(i >= 0 && i < _countof(arr) && "index out of range");
 
-			// Keep constexpr reads on the named union members so constant evaluation never
-			// touches the inactive runtime alias.
 			if consteval
 			{
-				return i < 4 ? ang[i] : lin[i - 4];
+				return
+					i == 0 ? ang.x :
+					i == 1 ? ang.y :
+					i == 2 ? ang.z :
+					i == 3 ? ang.w :
+					i == 4 ? lin.x :
+					i == 5 ? lin.y :
+					i == 6 ? lin.z :
+					         lin.w;
 			}
 			else
 			{
@@ -104,8 +112,6 @@ namespace pr::math
 		{
 			pr_assert(i >= 0 && i < _countof(arr) && "index out of range");
 
-			// Keep constexpr writes on the named union members so constant evaluation never
-			// touches the inactive runtime alias.
 			if consteval
 			{
 				return i < 4 ? ang[i] : lin[i - 4];

--- a/include/pr/math/types/vector8.h
+++ b/include/pr/math/types/vector8.h
@@ -85,15 +85,35 @@ namespace pr::math
 		}
 
 		// Array access
-		constexpr S const& operator [] (int i) const noexcept
+		constexpr S operator [] (int i) const noexcept
 		{
 			pr_assert(i >= 0 && i < _countof(arr) && "index out of range");
-			return arr[i];
+
+			// Keep constexpr reads on the named union members so constant evaluation never
+			// touches the inactive runtime alias.
+			if consteval
+			{
+				return i < 4 ? ang[i] : lin[i - 4];
+			}
+			else
+			{
+				return arr[i];
+			}
 		}
 		constexpr S& operator [] (int i) noexcept
 		{
 			pr_assert(i >= 0 && i < _countof(arr) && "index out of range");
-			return arr[i];
+
+			// Keep constexpr writes on the named union members so constant evaluation never
+			// touches the inactive runtime alias.
+			if consteval
+			{
+				return i < 4 ? ang[i] : lin[i - 4];
+			}
+			else
+			{
+				return arr[i];
+			}
 		}
 
 		// Constants


### PR DESCRIPTION
Route constexpr Vec8 indexing through the active ang/lin view and add compile-time coverage for reads and writes.