### PR TITLE
fix: zero rhs.w in Vec4&lt;double&gt; Dot3 AVX2 path to prevent NaN/Inf contamination

### DIFF
--- a/include/pr/math/tests/vector4_tests.h
+++ b/include/pr/math/tests/vector4_tests.h
@@ -158,6 +158,30 @@ namespace pr::math::tests
 			PR_EXPECT(Dot3(a, b) == T(-22)); // 3-component dot (ignores w)
 		}
 
+		// Dot3 must ignore w in both operands — NaN or infinity in w must not contaminate xyz result.
+		PRUnitTestMethod(Dot3WContract, float, double)
+		{
+			using vec4_t = Vec4<T>;
+
+			// lhs=(1,2,3), rhs=(2,3,4): expected xyz dot = 1*2+2*3+3*4 = 20
+			auto check = [&](T lhs_w, T rhs_w)
+			{
+				auto lhs = vec4_t(T(1), T(2), T(3), lhs_w);
+				auto rhs = vec4_t(T(2), T(3), T(4), rhs_w);
+				auto expected = T(20);
+				auto actual = Dot3(lhs, rhs);
+				PR_EXPECT(actual == expected);
+			};
+
+			check(T(7), T(9));
+			check(std::numeric_limits<T>::quiet_NaN(), T(9));
+			check(T(7), std::numeric_limits<T>::quiet_NaN());
+			check(std::numeric_limits<T>::infinity(), T(9));
+			check(T(7), std::numeric_limits<T>::infinity());
+			check(-std::numeric_limits<T>::infinity(), T(9));
+			check(T(7), -std::numeric_limits<T>::infinity());
+		}
+
 		// Component-wise modulus for Vec%Vec, Vec%scalar, and scalar%Vec across all element types.
 		PRUnitTestMethod(Modulus, float, double, int32_t, int64_t)
 		{

--- a/include/pr/math/types/vector4.h
+++ b/include/pr/math/types/vector4.h
@@ -1,4 +1,4 @@
-﻿//*****************************************************************************
+//*****************************************************************************
 // Maths library
 //  Copyright (c) Rylogic Ltd 2002
 //*****************************************************************************
@@ -460,8 +460,11 @@ namespace pr::math
 				}
 				else if constexpr (IntrinsicD)
 				{
+					// Zero w in both operands so that 0*NaN or 0*Inf in the w lane cannot
+					// contaminate the horizontal sum — the xyz result must always be finite when xyz inputs are.
 					auto a = _mm256_blend_pd(lhs.vec, _mm256_setzero_pd(), 0x8); // zero w of lhs
-					auto mul = _mm256_mul_pd(a, rhs.vec);
+					auto b = _mm256_blend_pd(rhs.vec, _mm256_setzero_pd(), 0x8); // zero w of rhs
+					auto mul = _mm256_mul_pd(a, b);
 					auto hi = _mm256_extractf128_pd(mul, 1);
 					auto lo = _mm256_castpd256_pd128(mul);
 					auto sum = _mm_add_pd(lo, hi);


### PR DESCRIPTION
## Problem

`Vec4<double>::Dot3` (AVX2/IntrinsicD path) promised to ignore `w` but only masked `lhs.w`, multiplying the masked `lhs` by the **unmodified** `rhs.vec`. IEEE 754 defines `0 × NaN = NaN` and `0 × ∞ = NaN`, so any garbage or special value in `rhs.w` would propagate through the horizontal add and corrupt a three-component result.

**Reproduced with** `lhs=(1,2,3,7)`, `rhs=(2,3,4,NaN)`: expected `20`, actual `NaN`.

The `float` `_mm_dp_ps` path was not affected — `_mm_dp_ps(…, 0x71)` ignores both `w` lanes by construction.

## Fix

Apply the same `_mm256_blend_pd(…, _mm256_setzero_pd(), 0x8)` w-zeroing mask to **both** operands before the element-wise multiply:

```cpp
auto a = _mm256_blend_pd(lhs.vec, _mm256_setzero_pd(), 0x8); // zero w of lhs
auto b = _mm256_blend_pd(rhs.vec, _mm256_setzero_pd(), 0x8); // zero w of rhs
auto mul = _mm256_mul_pd(a, b);
```

This is the minimal intrinsic change consistent with existing style, adding one instruction.

## Test

Added `Dot3WContract` (float, double) covering:
- ordinary `w` values (sanity baseline)  
- `lhs.w = NaN`, `rhs.w = NaN`
- `lhs.w = +∞`, `rhs.w = +∞`, `rhs.w = -∞`

All cases assert `Dot3((1,2,3,lhs_w),(2,3,4,rhs_w)) == 20`.

## Validation

Compiled and ran standalone regression against the worktree headers with VS 2026 / v145 / AVX2 / Debug x64. All 6 cases pass. `git diff --check` clean.