### PR TITLE
fix: Matrix::identity() sets wrong diagonal elements when transposed

### DIFF
--- a/include/pr/math/tests/matrix_tests.h
+++ b/include/pr/math/tests/matrix_tests.h
@@ -36,6 +36,48 @@ namespace pr::math::tests
 			}
 		}
 
+		// Regression: identity() on a transposed non-square matrix must place ones on the
+		// logical diagonal. Prior to the fix, cmps() mixed logical and physical dimensions so
+		// ones landed at wrong positions when the matrix was transposed.
+		PRUnitTestMethod(IdentityTransposedNonSquare)
+		{
+			// Matrix<double>(2,3) transposed → logical 3×2.
+			// Identity must have ones at (0,0) and (1,1) only.
+			{
+				auto m = Matrix<double>(2, 3);
+				m.transpose();
+				m.identity();
+
+				PR_EXPECT(m.vecs() == 3 && m.cmps() == 2);
+				PR_EXPECT(m(0, 0) == 1.0 && m(0, 1) == 0.0);
+				PR_EXPECT(m(1, 0) == 0.0 && m(1, 1) == 1.0);
+				PR_EXPECT(m(2, 0) == 0.0 && m(2, 1) == 0.0);
+			}
+
+			// Matrix<double>(3,2) transposed → logical 2×3.
+			// Identity must have ones at (0,0) and (1,1) only; (0,1), (0,2), (1,0), (1,2) are 0.
+			{
+				auto m = Matrix<double>(3, 2);
+				m.transpose();
+				m.identity();
+
+				PR_EXPECT(m.vecs() == 2 && m.cmps() == 3);
+				PR_EXPECT(m(0, 0) == 1.0 && m(0, 1) == 0.0 && m(0, 2) == 0.0);
+				PR_EXPECT(m(1, 0) == 0.0 && m(1, 1) == 1.0 && m(1, 2) == 0.0);
+			}
+
+			// Non-transposed non-square: sanity-check that the non-transposed path still works.
+			{
+				auto m = Matrix<double>(2, 4);
+				m.identity();
+
+				PR_EXPECT(m.vecs() == 2 && m.cmps() == 4);
+				for (int r = 0; r != 2; ++r)
+					for (int c = 0; c != 4; ++c)
+						PR_EXPECT(m(r, c) == (r == c ? 1.0 : 0.0));
+			}
+		}
+
 		PRUnitTestMethod(LUDecomposition)
 		{
 			auto m = MatrixLU<double>(4, 4, 

--- a/include/pr/math/types/matrix.h
+++ b/include/pr/math/types/matrix.h
@@ -335,11 +335,15 @@ namespace pr::math
 			return *this;
 		}
 
-		// Set this matrix to an identity matrix
+		// Set this matrix to an identity matrix.
+		// Uses logical (vec, cmp) access so the diagonal ones land at the correct positions
+		// regardless of transpose state and regardless of whether the matrix is square.
 		Matrix& identity() noexcept
 		{
 			zero();
-			for (int i = 0, istep = cmps() + 1, iend = size(); i < iend; i += istep) m_data[i] = S(1);
+			auto n = std::min(vecs(), cmps());
+			for (int i = 0; i != n; ++i)
+				(*this)(i, i) = S(1);
 			return *this;
 		}
 


### PR DESCRIPTION
## Summary

`Matrix::identity()` used a raw `m_data` stride of `cmps() + 1` to place ones on the diagonal. On a **transposed non-square** matrix, `cmps()` returns the *logical* column count (which equals `m_vecs` in physical storage terms), so the stride mismatches the physical layout and ones land at incorrect logical positions.

**Reproduction:**
```cpp
auto m = Matrix<double>(2, 3);
m.transpose();      // logical shape is now 3×2
m.identity();
// Before fix: m(0,1)==1, m(1,1)==0  ← wrong
// After fix:  m(0,0)==1, m(1,1)==1  ← correct
```

## Root Cause

```cpp
// Before — physical stride mismatch on transposed matrices
for (int i = 0, istep = cmps() + 1, iend = size(); i < iend; i += istep)
    m_data[i] = S(1);
```

`cmps()` accounts for the transposed flag (returns `m_vecs` when transposed), but `m_data` indexing is always physical (`m_cmps` columns per row). The two are in conflict for non-square transposed matrices.

## Fix

Replace the physical stride loop with logical indexed access, which already handles the transpose flag via the coordinate swap in `operator()`:

```cpp
// After — logical access, correct regardless of transpose state or shape
auto n = std::min(vecs(), cmps());
for (int i = 0; i != n; ++i)
    (*this)(i, i) = S(1);
```

## Files Changed

- **`include/pr/math/types/matrix.h`** — `identity()` method fixed
- **`include/pr/math/tests/matrix_tests.h`** — `IdentityTransposedNonSquare` regression test added

## Validation

All 63 math unit tests pass (VS2026/v145, Debug x64):
```
pr::math::tests::TestClass_Matrix.IdentityTransposedNonSquare ... success. (16 tests in 0.004 ms)
pr::math::tests::TestClass_Matrix.ZeroFillIdentity          ... success. (37 tests in 0.007 ms)
 **** UnitTest results: All 63 unit tests passed. (taking 110.465 ms) ****
```

`git diff --check` exits 0 (no whitespace issues).